### PR TITLE
CBMC runtime analysis: Record byte extract and update operations

### DIFF
--- a/cbmc_viewer/byteopt.py
+++ b/cbmc_viewer/byteopt.py
@@ -1,0 +1,143 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CBMC byte extract and update operations.
+
+This module displays all byte extract and update operations recorded by CBMC.
+It includes SSA expression corresponding to an extract or update, source location
+and the total number of extract/update operations.
+Inputs to the module is a json file obtained by running CBMC with the
+--show-byte-ops parse option, the project source and reporting directories.
+"""
+import logging
+
+import voluptuous
+import voluptuous.humanize
+
+from cbmc_viewer import filet
+from cbmc_viewer import parse
+from cbmc_viewer import srcloct
+from cbmc_viewer import templates
+from cbmc_viewer import util
+
+################################################################
+
+VALID_BYTE_OP_LIST_ITEM = voluptuous.schema_builder.Schema({
+    'sourceLocation': srcloct.VALID_SRCLOC,
+    'ssaExprString': str
+}, required=True)
+
+VALID_BYTE_OP_SUMMARY = voluptuous.schema_builder.Schema({
+    'summary': {
+        'byteExtractList': [VALID_BYTE_OP_LIST_ITEM],
+        'numOfExtracts': int,
+        'byteUpdateList': [VALID_BYTE_OP_LIST_ITEM],
+        'numOfUpdates': int
+        }
+}, required=True)
+
+################################################################
+
+class ByteOpSummary:
+
+    def __init__(self, json_file, srcdir):
+
+        self.summary = do_make_byteop(json_file, srcdir)
+        self.validate()
+
+    def __str__(self):
+        """Render the byte op summary as html."""
+        return templates.render_byteop_summary(self.summary)
+
+    def validate(self):
+        """Validate members of a summary object."""
+
+        return voluptuous.humanize.validate_with_humanized_errors(
+            self.__dict__, VALID_BYTE_OP_SUMMARY
+        )
+
+    def dump(self, filename=None, outdir='.'):
+        """Write the byte op summary to a file rendered as html."""
+
+        util.dump(self, filename or "byteop.html", outdir)
+
+################################################################
+# Json key tags to access elements in cbmc json output
+
+JSON_EXTRACT_KEY = 'byteExtractStats'
+JSON_EXTRACT_LIST_KEY = 'byteExtractList'
+JSON_EXTRACT_COUNT_KEY = 'numOfExtracts'
+JSON_UPDATE_KEY = 'byteUpdateStats'
+JSON_UPDATE_LIST_KEY = 'byteUpdateList'
+JSON_UPDATE_COUNT_KEY = 'numOfUpdates'
+JSON_BYTE_OP_KEY = 'byteOpsStats'
+JSON_SOURCE_LOC_KEY = 'sourceLocation'
+
+################################################################
+# Utility functions to generate byteop summary
+
+def extract_byte_op_data(json_data):
+    for item in json_data:
+        if JSON_BYTE_OP_KEY in item.keys():
+            return item[JSON_BYTE_OP_KEY]
+    return None
+
+def remove_ssa_expr(json_data):
+    JSON_REMOVE_KEY = 'ssaExpr'
+
+    json_extract_list = json_data.get(JSON_EXTRACT_KEY).get(JSON_EXTRACT_LIST_KEY)
+    json_update_list = json_data.get(JSON_UPDATE_KEY).get(JSON_UPDATE_LIST_KEY)
+
+    for item in json_extract_list:
+        item.pop(JSON_REMOVE_KEY)
+    for item in json_update_list:
+        item.pop(JSON_REMOVE_KEY)
+
+def get_src_location(json_data, root):
+    json_extract_list = json_data.get(JSON_EXTRACT_KEY).get(JSON_EXTRACT_LIST_KEY)
+    json_update_list = json_data.get(JSON_UPDATE_KEY).get(JSON_UPDATE_LIST_KEY)
+
+    root = srcloct.abspath(root)
+    for item in json_extract_list:
+        item[JSON_SOURCE_LOC_KEY] = srcloct.json_srcloc(item[JSON_SOURCE_LOC_KEY], root)
+    for item in json_update_list:
+        item[JSON_SOURCE_LOC_KEY] = srcloct.json_srcloc(item[JSON_SOURCE_LOC_KEY], root)
+
+def get_byte_op_metrics(json_file, root):
+    summary = {}
+
+    json_data = parse.parse_json_file(json_file)
+    for item in json_data:
+        if JSON_BYTE_OP_KEY in item.keys():
+            byteop = item[JSON_BYTE_OP_KEY]
+            remove_ssa_expr(byteop)
+            get_src_location(byteop, root)
+
+            summary['byteExtractList'] = byteop[JSON_EXTRACT_KEY][JSON_EXTRACT_LIST_KEY]
+            summary['numOfExtracts'] = byteop[JSON_EXTRACT_KEY][JSON_EXTRACT_COUNT_KEY]
+            summary['byteUpdateList'] = byteop[JSON_UPDATE_KEY][JSON_UPDATE_LIST_KEY]
+            summary['numOfUpdates'] = byteop[JSON_UPDATE_KEY][JSON_UPDATE_COUNT_KEY]
+            break
+
+    if not summary:
+        summary = {
+            'byteExtractList': [],
+            'numOfExtracts': 0,
+            'byteUpdateList': [],
+            'numOfUpdates': 0
+        }
+
+    return summary
+
+def fail(msg):
+    """Log failure and raise exception."""
+
+    logging.info(msg)
+    raise UserWarning(msg)
+
+def do_make_byteop(cbmc_byteop, srcdir):
+    if srcdir and cbmc_byteop:
+        if filet.is_json_file(cbmc_byteop):
+            return get_byte_op_metrics(cbmc_byteop, srcdir)
+        fail("Expected json file: {}"
+            .format(cbmc_byteop))

--- a/cbmc_viewer/byteopt.py
+++ b/cbmc_viewer/byteopt.py
@@ -89,6 +89,66 @@ JSON_UPDATE_COUNT_KEY = 'numOfUpdates'
 JSON_BYTE_OP_KEY = 'byteOpsStats'
 JSON_SOURCE_LOC_KEY = 'sourceLocation'
 
+# Example cbmc json output
+# [
+#   {
+#     "program": "CBMC 5.13.0 (cbmc-5.13.1-44-g31340ca28)"
+#   },
+#   ...
+#   {
+#     "byteOpsStats": {
+#       "byteExtractStats": {
+#         "byteExtractList": [ ],
+#         "numOfExtracts": 0
+#       },
+#       "byteUpdateStats": {
+#         "byteUpdateList": [ ],
+#         "numOfUpdates": 0
+#       }
+#     }
+#   },
+#   ...
+#   {
+#     "byteOpsStats": {
+#       "byteExtractStats": {
+#         "byteExtractList": [
+#           {
+#             "sourceLocation": {
+#               "file": "byte_extract_code.c",
+#               "function": "main",
+#               "line": "12",
+#               "workingDirectory": "..."
+#             },
+#             "ssaExpr": {...},
+#             "ssaExprString": "... byte_update_little_endian ..."
+#           }
+#         ],
+#         "numOfExtracts": 1
+#       },
+#       "byteUpdateStats": {
+#         "byteUpdateList": [
+#           {
+#             "sourceLocation": {
+#               "file": "byte_extract_code.c",
+#               "function": "main",
+#               "line": "12",
+#               "workingDirectory": "..."
+#             },
+#             "ssaExpr": {...},
+#             "ssaExprString": "... byte_update_little_endian ..."
+#           }
+#         ],
+#         "numOfUpdates": 1
+#       }
+#     }
+#   },
+#   ...
+#   {
+#     "messageText": "...",
+#     "messageType": "STATUS-MESSAGE"
+#   }
+# ]
+
 ################################################################
 # Utility functions to generate byteop summary
 
@@ -130,11 +190,11 @@ def get_byte_op_metrics(json_file, root):
 
             summary['byteExtractList'].extend(
                 byteop[JSON_EXTRACT_KEY][JSON_EXTRACT_LIST_KEY])
-            summary['numOfExtracts'] = summary.setdefault('numOfExtracts',0) + \
+            summary['numOfExtracts'] += \
                 byteop[JSON_EXTRACT_KEY][JSON_EXTRACT_COUNT_KEY]
             summary['byteUpdateList'].extend(
                 byteop[JSON_UPDATE_KEY][JSON_UPDATE_LIST_KEY])
-            summary['numOfUpdates'] = summary.setdefault('numOfUpdates',0) + \
+            summary['numOfUpdates'] += \
                 byteop[JSON_UPDATE_KEY][JSON_UPDATE_COUNT_KEY]
 
     return summary

--- a/cbmc_viewer/byteopt.py
+++ b/cbmc_viewer/byteopt.py
@@ -76,12 +76,6 @@ JSON_SOURCE_LOC_KEY = 'sourceLocation'
 ################################################################
 # Utility functions to generate byteop summary
 
-def extract_byte_op_data(json_data):
-    for item in json_data:
-        if JSON_BYTE_OP_KEY in item.keys():
-            return item[JSON_BYTE_OP_KEY]
-    return None
-
 def remove_ssa_expr(json_data):
     JSON_REMOVE_KEY = 'ssaExpr'
 
@@ -113,11 +107,14 @@ def get_byte_op_metrics(json_file, root):
             remove_ssa_expr(byteop)
             get_src_location(byteop, root)
 
-            summary['byteExtractList'] = byteop[JSON_EXTRACT_KEY][JSON_EXTRACT_LIST_KEY]
-            summary['numOfExtracts'] = byteop[JSON_EXTRACT_KEY][JSON_EXTRACT_COUNT_KEY]
-            summary['byteUpdateList'] = byteop[JSON_UPDATE_KEY][JSON_UPDATE_LIST_KEY]
-            summary['numOfUpdates'] = byteop[JSON_UPDATE_KEY][JSON_UPDATE_COUNT_KEY]
-            break
+            summary.setdefault('byteExtractList',[]).extend(
+                byteop[JSON_EXTRACT_KEY][JSON_EXTRACT_LIST_KEY])
+            summary['numOfExtracts'] = summary.setdefault('numOfExtracts',0) + \
+                byteop[JSON_EXTRACT_KEY][JSON_EXTRACT_COUNT_KEY]
+            summary.setdefault('byteUpdateList',[]).extend(
+                byteop[JSON_UPDATE_KEY][JSON_UPDATE_LIST_KEY])
+            summary['numOfUpdates'] = summary.setdefault('numOfUpdates',0) + \
+                byteop[JSON_UPDATE_KEY][JSON_UPDATE_COUNT_KEY]
 
     if not summary:
         summary = {

--- a/cbmc_viewer/doc/make-byteop.md
+++ b/cbmc_viewer/doc/make-byteop.md
@@ -4,18 +4,22 @@ make-byteop -- list all byte extract and update operations
 
 # Synopsis
 
-	usage: make-byteop [-h] [--byteop FILE] [--srcdir SRCDIR]
-					   [--reportdir REPORTDIR] [--verbose] [--debug]
+	usage: make-byteop [-h] [--byteop FILE] [--srcdir SRCDIR] 
+					   [--verbose] [--debug]
 
 # Description
 
 This is a front end for the byteopt module that viewer uses to scan
-the results of cbmc byte extract/update metric collection. The output is a json file that describes the SSA expression and source location corresponding to an extract or update along with the total number of extract/update operations.
+the results of cbmc byte extract/update metric collection. The output 
+is a json file that describes the SSA expression and source location 
+corresponding to an extract or update along with the total number of 
+extract/update operations.
 
 Simple uses of make-byteop are
 
-	# Generate the byte op metric data from output of "cbmc --show-byte-ops"
-	# cbmc --show-byte-ops --json-ui program.goto > byteops.json
-	make-byteop --byteop byteops.json --srcdir /usr/project --reportdir html_report_dir
+	# Generate the list of byte extract and update operation from output 
+	# of "cbmc --show-byte-ops"
+	# cbmc --show-byte-ops --json-ui program.goto > byteop.json
+	make-byteop --byteop byteops.json --srcdir /usr/project
 
 Type "make-byteop --help" for a complete list of command line options.

--- a/cbmc_viewer/doc/make-byteop.md
+++ b/cbmc_viewer/doc/make-byteop.md
@@ -1,0 +1,21 @@
+# Name
+
+make-byteop -- list all byte extract and update operations
+
+# Synopsis
+
+	usage: make-byteop [-h] [--byteop FILE] [--srcdir SRCDIR]
+					   [--reportdir REPORTDIR] [--verbose] [--debug]
+
+# Description
+
+This is a front end for the byteopt module that viewer uses to scan
+the results of cbmc byte extract/update metric collection. The output is a json file that describes the SSA expression and source location corresponding to an extract or update along with the total number of extract/update operations.
+
+Simple uses of make-byteop are
+
+	# Generate the byte op metric data from output of "cbmc --show-byte-ops"
+	# cbmc --show-byte-ops --json-ui program.goto > byteops.json
+	make-byteop --byteop byteops.json --srcdir /usr/project --reportdir html_report_dir
+
+Type "make-byteop --help" for a complete list of command line options.

--- a/cbmc_viewer/make_byteop.py
+++ b/cbmc_viewer/make_byteop.py
@@ -24,7 +24,6 @@ def create_parser():
 
     optionst.byteop(parser)
     optionst.srcdir(parser)
-    optionst.reportdir(parser)
 
     optionst.log(parser)
 
@@ -39,14 +38,9 @@ def main():
     args = optionst.defaults(args)
 
     try:
-        byteop = byteopt.ByteOpSummary(args.byteop,
+        byteop = byteopt.do_make_byteop(args.byteop,
                                        args.srcdir)
-
-        htmldir = os.path.join(args.reportdir, "html")
-        jsondir = os.path.join(args.reportdir, "json")
-
-        byteop.dump(filename='viewer-byteop', outdir=jsondir)
-        byteop.render_report(outdir=htmldir)
+        print(byteop)
     except UserWarning as error:
         sys.exit(error)
 

--- a/cbmc_viewer/make_byteop.py
+++ b/cbmc_viewer/make_byteop.py
@@ -10,7 +10,6 @@
 
 import argparse
 import sys
-import os
 
 from cbmc_viewer import byteopt
 from cbmc_viewer import optionst

--- a/cbmc_viewer/make_byteop.py
+++ b/cbmc_viewer/make_byteop.py
@@ -10,6 +10,7 @@
 
 import argparse
 import sys
+import os
 
 from cbmc_viewer import byteopt
 from cbmc_viewer import optionst
@@ -40,7 +41,12 @@ def main():
     try:
         byteop = byteopt.ByteOpSummary(args.byteop,
                                        args.srcdir)
-        byteop.dump(outdir=args.reportdir)
+
+        htmldir = os.path.join(args.reportdir, "html")
+        jsondir = os.path.join(args.reportdir, "json")
+
+        byteop.dump(filename='viewer-byteop', outdir=jsondir)
+        byteop.render_report(outdir=htmldir)
     except UserWarning as error:
         sys.exit(error)
 

--- a/cbmc_viewer/make_byteop.py
+++ b/cbmc_viewer/make_byteop.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python3
 
-#!/usr/bin/env python3
-
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 

--- a/cbmc_viewer/make_byteop.py
+++ b/cbmc_viewer/make_byteop.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+#!/usr/bin/env python3
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- mode: python-mode -*-
+
+"""List CBMC Byte Extract/Update metrics."""
+
+
+import argparse
+import sys
+
+from cbmc_viewer import byteopt
+from cbmc_viewer import optionst
+
+def create_parser():
+    """Command line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="List CBMC byte extract and update metrics."
+    )
+
+    optionst.byteop(parser)
+    optionst.srcdir(parser)
+    optionst.reportdir(parser)
+
+    optionst.log(parser)
+
+    return parser
+
+################################################################
+
+def main():
+    """List CBMC byte extract and update metrics."""
+
+    args = create_parser().parse_args()
+    args = optionst.defaults(args)
+
+    try:
+        byteop = byteopt.ByteOpSummary(args.byteop,
+                                       args.srcdir)
+        byteop.dump(outdir=args.reportdir)
+    except UserWarning as error:
+        sys.exit(error)
+
+if __name__ == "__main__":
+    main()

--- a/cbmc_viewer/optionst.py
+++ b/cbmc_viewer/optionst.py
@@ -120,12 +120,10 @@ def byteop(parser):
     parser.add_argument(
         '--byteop',
         metavar='FILE',
-        default='byteops.json',
         help="""
         CBMC byte extract and update metrics.
         A json file containing the output of
         'cbmc --show-byte-ops --json-ui'.
-        (Default: %(default)s)
         """
     )
     return parser

--- a/cbmc_viewer/optionst.py
+++ b/cbmc_viewer/optionst.py
@@ -114,6 +114,22 @@ def property(parser):
     )
     return parser
 
+def byteop(parser):
+    'Define --byteop command line option.'
+
+    parser.add_argument(
+        '--byteop',
+        metavar='FILE',
+        default='byteops.json',
+        help="""
+        CBMC byte extract and update metrics.
+        A json file containing the output of
+        'cbmc --show-byte-ops --json-ui'.
+        (Default: %(default)s)
+        """
+    )
+    return parser
+
 def exclude(parser):
     'Define --exclude command line option.'
 

--- a/cbmc_viewer/report.py
+++ b/cbmc_viewer/report.py
@@ -23,7 +23,7 @@ def progress_default(string):
     logging.info(string)
 
 def report(config, sources, symbols, results, coverage, traces, properties,
-           loops, report_dir='.', progress=progress_default):
+           loops, byteops, report_dir='.', progress=progress_default):
     """Assemble the full report for cbmc viewer."""
 
     # The report is assembled from many sources of data
@@ -60,3 +60,8 @@ def report(config, sources, symbols, results, coverage, traces, properties,
         markup_trace.Trace(name, trace, symbols, properties, loops, snippets).dump(
             outdir=trace_dir)
     progress("Annotating traces", True)
+
+    progress("Preparing byte op report")
+    byteops.dump(
+            outdir=report_dir)
+    progress("Preparing byte op report", True)

--- a/cbmc_viewer/report.py
+++ b/cbmc_viewer/report.py
@@ -23,7 +23,7 @@ def progress_default(string):
     logging.info(string)
 
 def report(config, sources, symbols, results, coverage, traces, properties,
-           loops, byteop, report_dir='.', progress=progress_default):
+           loops, byteop=None, report_dir='.', progress=progress_default):
     """Assemble the full report for cbmc viewer."""
 
     # The report is assembled from many sources of data
@@ -61,6 +61,7 @@ def report(config, sources, symbols, results, coverage, traces, properties,
             outdir=trace_dir)
     progress("Annotating traces", True)
 
-    progress("Preparing byte op report")
-    byteop.render_report(outdir=report_dir)
-    progress("Preparing byte op report", True)
+    if byteop:
+        progress("Preparing byte op report")
+        byteop.render_report(outdir=report_dir)
+        progress("Preparing byte op report", True)

--- a/cbmc_viewer/report.py
+++ b/cbmc_viewer/report.py
@@ -23,7 +23,7 @@ def progress_default(string):
     logging.info(string)
 
 def report(config, sources, symbols, results, coverage, traces, properties,
-           loops, byteops, report_dir='.', progress=progress_default):
+           loops, byteop, report_dir='.', progress=progress_default):
     """Assemble the full report for cbmc viewer."""
 
     # The report is assembled from many sources of data
@@ -62,6 +62,5 @@ def report(config, sources, symbols, results, coverage, traces, properties,
     progress("Annotating traces", True)
 
     progress("Preparing byte op report")
-    byteops.dump(
-            outdir=report_dir)
+    byteop.render_report(outdir=report_dir)
     progress("Preparing byte op report", True)

--- a/cbmc_viewer/templates.py
+++ b/cbmc_viewer/templates.py
@@ -14,6 +14,9 @@ SUMMARY_TEMPLATE = 'summary.jinja.html'
 CODE_TEMPLATE = 'code.jinja.html'
 TRACE_TEMPLATE = 'trace.jinja.html'
 
+# runtime analysis metrics
+BYTEOP_SUMMARY_TEMPLATE = 'byteop.jinja.html'
+
 ENV = None
 
 def env():
@@ -48,4 +51,11 @@ def render_trace(name, desc, srcloc, steps):
 
     return env().get_template(TRACE_TEMPLATE).render(
         prop_name=name, prop_desc=desc, prop_srcloc=srcloc, steps=steps
+    )
+
+def render_byteop_summary(byteop_summary):
+    """Render byte op metrics as html."""
+
+    return env().get_template(BYTEOP_SUMMARY_TEMPLATE).render(
+        byteops=byteop_summary
     )

--- a/cbmc_viewer/templates/byteop.jinja.html
+++ b/cbmc_viewer/templates/byteop.jinja.html
@@ -1,0 +1,109 @@
+{% import 'link.jinja.html' as link %}
+
+<html>
+  <head>
+    <title>CBMC</title>
+    <style type="text/css">
+      .byteop table td
+      {
+        padding-right: 1em; 
+      }
+
+      .byteop table th
+      {
+        padding-right: 1em;
+        text-align: left;
+        padding-bottom: 1em;
+      }
+      .ssaExtract
+      {
+        display: none;
+      }
+      .ssaUpdate
+      {
+        display: none;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>CBMC ByteOp Metrics Report</h1>
+
+    <div class="byteop">
+      <h2>Byte Extracts</h2>
+      <p>
+        Number of byte extracts: {{byteops.numOfExtracts}}
+      </p>
+      {% if byteops.numOfExtracts > 0 %}
+      <table class="byteop">
+        <tr>
+          <th class="func">Function</th>
+          <th class="file">File</th>
+          <th class="line">Line</th>
+          <th class="ssa_expr"><button onclick="toggleSSA(0)" id="showExtractSSA">Show SSA Expr</button></th>
+        </tr>
+        {% for byte_extract in byteops.byteExtractList|sort(attribute="sourceLocation.function,sourceLocation.file") %}
+          {% set loc = byte_extract.sourceLocation %}
+          <tr>
+            <td class="func">{{link.to_line(loc.file, loc.line, loc.function)}}</td>
+            <td class="file">{{link.to_file(loc.file, loc.file)}}</td>
+            <td class="line">{{link.to_line(loc.file, loc.line, loc.line)}}</td>
+            <td class="ssaExtract">{{byte_extract.ssaExprString}}</td>
+          </tr>
+        {% endfor %}
+      </table>
+      {% endif %}
+    </div>
+
+    <div class="byteop">
+      <h2>Byte Updates</h2>
+      <p>
+        Number of byte updates: {{byteops.numOfUpdates}}
+      </p>
+      {% if byteops.numOfUpdates > 0 %}
+      <table class="byteop">
+        <tr>
+          <th class="func">Function</th>
+          <th class="file">File</th>
+          <th class="line">Line</th>
+          <th class="ssa_expr"><button onclick="toggleSSA(1)" id="showUpdateSSA">Show SSA Expr</button></th>
+        </tr>
+        {% for byte_update in byteops.byteUpdateList|sort(attribute="sourceLocation.function,sourceLocation.file") %}
+          {% set loc = byte_update.sourceLocation %}
+          <tr>
+            <td class="func">{{link.to_line(loc.file, loc.line, loc.function)}}</td>
+            <td class="file">{{link.to_file(loc.file, loc.file)}}</td>
+            <td class="line">{{link.to_line(loc.file, loc.line, loc.line)}}</td>
+            <td class="ssaUpdate">{{byte_update.ssaExprString}}</td>
+          </tr>
+        {% endfor %}
+      </table>
+      {% endif %}
+    </div>
+  </body>
+  <script type="text/javascript">
+    function toggleSSA(byteop){
+    if(byteop == 0)
+    {
+      var x = document.getElementsByClassName("ssaExtract");
+      var button = document.getElementById("showExtractSSA");
+    }
+    else
+    {
+      var x = document.getElementsByClassName("ssaUpdate");
+      var button = document.getElementById("showUpdateSSA");
+    }
+
+    for (elt of x){
+      if(elt.style.display == "none"){
+        elt.style.display = "block";
+        button.innerHTML = "Hide SSA Expr";
+      }
+      else {
+        elt.style.display = "none";
+        button.innerHTML = "Show SSA Expr";
+      }
+    }
+  }
+  </script>
+</html>

--- a/cbmc_viewer/viewer.py
+++ b/cbmc_viewer/viewer.py
@@ -216,11 +216,14 @@ def viewer():
     dump(symbols, 'viewer-symbol.json')
     progress("Preparing symbol table", True)
 
-    progress("Scanning byteop data")
-    byteop = byteopt.do_make_byteop(args.byteop,
+    if args.byteop:
+        progress("Scanning byteop data")
+        byteop = byteopt.do_make_byteop(args.byteop,
                                      args.srcdir)
-    dump(byteop, 'viewer-byteop.json')
-    progress("Scanning byteop data", True)
+        dump(byteop, 'viewer-byteop.json')
+        progress("Scanning byteop data", True)
+    else:
+        byteop = None
 
     config = configt.Config(args.config)
     report.report(config, sources, symbols, results, coverage, traces,

--- a/cbmc_viewer/viewer.py
+++ b/cbmc_viewer/viewer.py
@@ -217,13 +217,13 @@ def viewer():
     progress("Preparing symbol table", True)
 
     progress("Scanning byteop data")
-    byteops = byteopt.ByteOpSummary(args.byteop,
+    byteop = byteopt.do_make_byteop(args.byteop,
                                      args.srcdir)
-    dump(json.dumps(byteops.summary, indent=2), 'viewer-byteop.json')
+    dump(byteop, 'viewer-byteop.json')
     progress("Scanning byteop data", True)
 
     config = configt.Config(args.config)
     report.report(config, sources, symbols, results, coverage, traces,
-                  properties, loops, byteops, htmldir, progress)
+                  properties, loops, byteop, htmldir, progress)
 
     global_progress("CBMC viewer", True)

--- a/cbmc_viewer/viewer.py
+++ b/cbmc_viewer/viewer.py
@@ -10,6 +10,7 @@ and with lists of property violations and traces for each violation.
 
 import argparse
 import datetime
+import json
 import logging
 import os
 
@@ -25,6 +26,9 @@ from cbmc_viewer import sourcet
 from cbmc_viewer import symbolt
 from cbmc_viewer import tracet
 
+# runtime analysis metrics
+from cbmc_viewer import byteopt
+
 def create_parser():
     """Create the command line parser."""
 
@@ -39,6 +43,9 @@ def create_parser():
     optionst.result(cbmc_data)
     optionst.coverage(cbmc_data)
     optionst.property(cbmc_data)
+
+    # runtime analysis metrics
+    optionst.byteop(cbmc_data)
 
     proof_sources = parser.add_argument_group('Sources')
     optionst.srcdir(proof_sources)
@@ -209,8 +216,14 @@ def viewer():
     dump(symbols, 'viewer-symbol.json')
     progress("Preparing symbol table", True)
 
+    progress("Scanning byteop data")
+    byteops = byteopt.ByteOpSummary(args.byteop,
+                                     args.srcdir)
+    dump(json.dumps(byteops.summary, indent=2), 'viewer-byteop.json')
+    progress("Scanning byteop data", True)
+
     config = configt.Config(args.config)
     report.report(config, sources, symbols, results, coverage, traces,
-                  properties, loops, htmldir, progress)
+                  properties, loops, byteops, htmldir, progress)
 
     global_progress("CBMC viewer", True)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setuptools.setup(
             "make-result = cbmc_viewer.make_result:main",
             "make-source = cbmc_viewer.make_source:main",
             "make-symbol = cbmc_viewer.make_symbol:main",
-            "make-trace = cbmc_viewer.make_trace:main"
+            "make-trace = cbmc_viewer.make_trace:main",
+            "make-byteop = cbmc_viewer.make_byteop:main"
         ]
     }
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add module to generate byte op metric report using CBMC output produced by --show-byte-ops. Takes a json file as input and generates a html report with number of extract/update operations, SSA expr and source location corresponding to each extract/update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
