### PR TITLE
CBMC runtime analysis: Record pointer alias analysis metric

### DIFF
--- a/cbmc_viewer/aliast.py
+++ b/cbmc_viewer/aliast.py
@@ -41,8 +41,8 @@ VALID_ALIAS = voluptuous.schema_builder.Schema({
 
 VALID_ALIAS_SUMMARY = voluptuous.schema_builder.Schema({
     'summary': VALID_ALIAS,
-    'max': int,
-    'total': int
+    'max': int, # max points-to set size
+    'total': int # total = sum(points_to_set_size * num_of_deref)
     },required=True)
 
 ################################################################
@@ -123,11 +123,11 @@ JSON_POINTER_KEY = 'Pointer'
 def get_max_total(alias_summary):
     max_val = 0
     total = 0
-    for alias_item in alias_summary.items():
-        if int(alias_item[1][JSON_POINTS_TO_SET_SIZE_KEY]) > max_val:
-            max_val = int(alias_item[1][JSON_POINTS_TO_SET_SIZE_KEY])
-        total += int(alias_item[1][JSON_POINTS_TO_SET_SIZE_KEY]) * \
-            alias_item[1]['numOfDeref']
+    for pointer, data in alias_summary.items():
+        if int(data[JSON_POINTS_TO_SET_SIZE_KEY]) > max_val:
+            max_val = int(data[JSON_POINTS_TO_SET_SIZE_KEY])
+        total += int(data[JSON_POINTS_TO_SET_SIZE_KEY]) * \
+            data['numOfDeref']
 
     return max_val, total
 
@@ -136,15 +136,12 @@ def get_alias_item(json_item):
     json_item.pop(JSON_POINTER_KEY)
     json_item.update({"numOfDeref": 1})
 
-    alias_item = {}
-    alias_item[pointer] = json_item
-
-    return alias_item
+    return {pointer: json_item}
 
 def is_equal(summary, item):
     for key in item.keys():
         if key in summary.keys():
-            is_equal_return = all([item[key][k] == summary[key][k] \
+            is_equal_return = all([item[key][k] == summary[key][k]
                 for k in item[key].keys() if k not in ['numOfDeref']])
             if(is_equal_return):
                 summary[key]['numOfDeref'] += 1

--- a/cbmc_viewer/aliast.py
+++ b/cbmc_viewer/aliast.py
@@ -1,0 +1,136 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CBMC points-to set metric.
+
+This module displays the size and contents of the points-to sets for
+pointer dereferencing in CBMC. The module also calculates and displays
+the number of dereferences of a pointer.
+Inputs to the module is a json file obtained by running CBMC with the
+--show-points-to-sets parse option and the project reporting directory.
+"""
+
+import logging
+
+import voluptuous
+import voluptuous.humanize
+
+from cbmc_viewer import filet
+from cbmc_viewer import parse
+from cbmc_viewer import srcloct
+from cbmc_viewer import templates
+from cbmc_viewer import util
+
+################################################################
+
+VALID_ALIAS_ITEM = voluptuous.schema_builder.Schema({
+    'PointsToSetSize': int,
+    'PointsToSet': list,
+    'RetainedValuesSetSize': int, # subset of points-to sets
+    'RetainedValuesSet': list,
+    'Value': str,
+    'numOfDeref': int
+    },required=True)
+
+VALID_ALIAS = voluptuous.schema_builder.Schema({
+    str : VALID_ALIAS_ITEM # str here stores the pointer variable
+    })
+
+VALID_SUMMARY = voluptuous.schema_builder.Schema({
+    'summary': VALID_ALIAS,
+    'max': int,
+    'total': int
+    },required=True)
+
+################################################################
+
+class AliasSummary:
+
+    def __init__(self, json_file):
+        self.summary = do_make_alias(json_file)
+        self.max, self.total = get_max_total(self.summary)
+        self.validate()
+
+    def __str__(self):
+        """Render the points-to set summary as html."""
+        return templates.render_alias_summary(self)
+
+    def validate(self):
+        """Validate members of a summary object."""
+
+        return voluptuous.humanize.validate_with_humanized_errors(
+            self.__dict__, VALID_SUMMARY
+        )
+
+    def dump(self, filename=None, outdir='.'):
+        """Write the points-to set summary to a file rendered as html."""
+
+        util.dump(self, filename or "alias.html", outdir)
+
+################################################################
+# Json key tags to access elements in cbmc json output
+
+JSON_POINTS_TO_SET_SIZE_KEY = 'PointsToSetSize'
+JSON_POINTER_KEY = 'Pointer'
+
+################################################################
+# Utility functions to generate byteop summary
+
+def get_max_total(alias_summary):
+    max_val = 0
+    total = 0
+    for alias_item in alias_summary.items():
+        if int(alias_item[1][JSON_POINTS_TO_SET_SIZE_KEY]) > max_val:
+            max_val = int(alias_item[1][JSON_POINTS_TO_SET_SIZE_KEY])
+        total += int(alias_item[1][JSON_POINTS_TO_SET_SIZE_KEY]) * alias_item[1]['numOfDeref']
+
+    return max_val, total
+
+def get_alias_item(json_item):
+    pointer = json_item[JSON_POINTER_KEY]
+    json_item.pop(JSON_POINTER_KEY)
+    json_item.update({"numOfDeref": 1})
+
+    alias_item = {}
+    alias_item[pointer] = json_item
+
+    return alias_item
+
+def is_equal(summary, item):
+    for key in item.keys():
+        if key in summary.keys():
+            is_equal_return = all([item[key][k] == summary[key][k] for k in item[key].keys() if k not in ['numOfDeref']])
+            if(is_equal_return):
+                summary[key]['numOfDeref'] += 1
+            return is_equal_return
+        else:
+            return False;
+
+def get_alias_metrics(json_file):
+    summary = {}
+
+    json_data = parse.parse_json_file(json_file)
+    for item in json_data:
+        if JSON_POINTER_KEY in item.keys():
+            alias_item = get_alias_item(item)
+            if not summary:
+                summary.update(alias_item)
+                continue
+
+            if not is_equal(summary, alias_item):
+                summary.update(alias_item)
+
+    return summary
+
+def fail(msg):
+    """Log failure and raise exception."""
+
+    logging.info(msg)
+    raise UserWarning(msg)
+
+def do_make_alias(cbmc_alias):
+    if cbmc_alias:
+        if filet.is_json_file(cbmc_alias):
+            return get_alias_metrics(cbmc_alias)
+        fail("Expected json file: {}"
+             .format(cbmc_alias))

--- a/cbmc_viewer/doc/make-alias.md
+++ b/cbmc_viewer/doc/make-alias.md
@@ -4,21 +4,20 @@ make-alias -- list points-to set metrics
 
 # Synopsis
 
-	usage: make-alias [-h] [--alias FILE] [--reportdir REPORTDIR] 
-                      [--verbose] [--debug]
+	usage: make-alias [-h] [--alias FILE] [--verbose] [--debug]
 
 # Description
 
 This is a front end for the aliast module that viewer uses to scan
-the results of cbmc pointer alias analysis, specifically points-to 
+the results of cbmc pointer alias analysis, specifically points-to
 set information. The output is a json file that describes the size
 and contents of the points-to set for pointer dereferencing.
 
 Simple uses of make-alias are
 
-    # Generate the points-to set metric data from output of 
+    # Generate the list points-to set metrics from output of
     # "cbmc --show-points-to-sets"
     # cbmc --show-points-to-sets --json-ui program.goto > alias.json
-    make-alias --alias alias.json --reportdir html_report_dir
+    make-alias --alias alias.json
 
 Type "make-alias --help" for a complete list of command line options.

--- a/cbmc_viewer/doc/make-alias.md
+++ b/cbmc_viewer/doc/make-alias.md
@@ -1,0 +1,24 @@
+# Name
+
+make-alias -- list points-to set metrics
+
+# Synopsis
+
+	usage: make-alias [-h] [--alias FILE] [--reportdir REPORTDIR] 
+                      [--verbose] [--debug]
+
+# Description
+
+This is a front end for the aliast module that viewer uses to scan
+the results of cbmc pointer alias analysis, specifically points-to 
+set information. The output is a json file that describes the size
+and contents of the points-to set for pointer dereferencing.
+
+Simple uses of make-alias are
+
+    # Generate the points-to set metric data from output of 
+    # "cbmc --show-points-to-sets"
+    # cbmc --show-points-to-sets --json-ui program.goto > alias.json
+    make-alias --alias alias.json --reportdir html_report_dir
+
+Type "make-alias --help" for a complete list of command line options.

--- a/cbmc_viewer/make_alias.py
+++ b/cbmc_viewer/make_alias.py
@@ -22,8 +22,6 @@ def create_parser():
     )
 
     optionst.alias(parser)
-    optionst.reportdir(parser)
-
     optionst.log(parser)
 
     return parser
@@ -37,8 +35,8 @@ def main():
     args = optionst.defaults(args)
 
     try:
-        alias = aliast.AliasSummary(args.alias)
-        alias.dump(outdir=args.reportdir)
+        alias = aliast.do_make_alias(args.alias)
+        print(alias)
     except UserWarning as error:
         sys.exit(error)
 

--- a/cbmc_viewer/make_alias.py
+++ b/cbmc_viewer/make_alias.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- mode: python-mode -*-
+
+"""List CBMC points-to set metrics."""
+
+
+import argparse
+import sys
+
+from cbmc_viewer import aliast
+from cbmc_viewer import optionst
+
+def create_parser():
+    """Command line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="List CBMC points-to set metrics."
+    )
+
+    optionst.alias(parser)
+    optionst.reportdir(parser)
+
+    optionst.log(parser)
+
+    return parser
+
+################################################################
+
+def main():
+    """List CBMC points-to set metrics."""
+
+    args = create_parser().parse_args()
+    args = optionst.defaults(args)
+
+    try:
+        alias = aliast.AliasSummary(args.alias)
+        alias.dump(outdir=args.reportdir)
+    except UserWarning as error:
+        sys.exit(error)
+
+if __name__ == "__main__":
+    main()

--- a/cbmc_viewer/optionst.py
+++ b/cbmc_viewer/optionst.py
@@ -120,12 +120,10 @@ def alias(parser):
     parser.add_argument(
         '--alias',
         metavar='FILE',
-        default='alias.json',
         help="""
         CBMC points-to set metrics.
         A json file containing the output of
         'cbmc --show-points-to-sets --json-ui'.
-        (Default: %(default)s)
         """
     )
     return parser

--- a/cbmc_viewer/optionst.py
+++ b/cbmc_viewer/optionst.py
@@ -114,6 +114,22 @@ def property(parser):
     )
     return parser
 
+def alias(parser):
+    'Define --alias command line option.'
+
+    parser.add_argument(
+        '--alias',
+        metavar='FILE',
+        default='alias.json',
+        help="""
+        CBMC points-to set metrics.
+        A json file containing the output of
+        'cbmc --show-points-to-sets --json-ui'.
+        (Default: %(default)s)
+        """
+    )
+    return parser
+
 def exclude(parser):
     'Define --exclude command line option.'
 

--- a/cbmc_viewer/report.py
+++ b/cbmc_viewer/report.py
@@ -23,7 +23,7 @@ def progress_default(string):
     logging.info(string)
 
 def report(config, sources, symbols, results, coverage, traces, properties,
-           loops, report_dir='.', progress=progress_default):
+           loops, alias, report_dir='.', progress=progress_default):
     """Assemble the full report for cbmc viewer."""
 
     # The report is assembled from many sources of data
@@ -60,3 +60,8 @@ def report(config, sources, symbols, results, coverage, traces, properties,
         markup_trace.Trace(name, trace, symbols, properties, loops, snippets).dump(
             outdir=trace_dir)
     progress("Annotating traces", True)
+
+    progress("Preparing points-to set summary report")
+    alias.dump(
+            outdir=report_dir)
+    progress("Preparing points-to set summary report", True)

--- a/cbmc_viewer/report.py
+++ b/cbmc_viewer/report.py
@@ -23,7 +23,7 @@ def progress_default(string):
     logging.info(string)
 
 def report(config, sources, symbols, results, coverage, traces, properties,
-           loops, alias, report_dir='.', progress=progress_default):
+           loops, alias=None, report_dir='.', progress=progress_default):
     """Assemble the full report for cbmc viewer."""
 
     # The report is assembled from many sources of data
@@ -61,7 +61,7 @@ def report(config, sources, symbols, results, coverage, traces, properties,
             outdir=trace_dir)
     progress("Annotating traces", True)
 
-    progress("Preparing points-to set summary report")
-    alias.dump(
-            outdir=report_dir)
-    progress("Preparing points-to set summary report", True)
+    if alias:
+        progress("Preparing points-to set summary report")
+        alias.render_report(outdir=report_dir)
+        progress("Preparing points-to set summary report", True)

--- a/cbmc_viewer/templates.py
+++ b/cbmc_viewer/templates.py
@@ -14,6 +14,9 @@ SUMMARY_TEMPLATE = 'summary.jinja.html'
 CODE_TEMPLATE = 'code.jinja.html'
 TRACE_TEMPLATE = 'trace.jinja.html'
 
+# runtime analysis metrics
+ALIAS_SUMMARY_TEMPLATE = 'alias.jinja.html'
+
 ENV = None
 
 def env():
@@ -48,4 +51,12 @@ def render_trace(name, desc, srcloc, steps):
 
     return env().get_template(TRACE_TEMPLATE).render(
         prop_name=name, prop_desc=desc, prop_srcloc=srcloc, steps=steps
+    )
+
+def render_alias_summary(alias_summary):
+    """Render points-to set metrics as html."""
+
+    return env().get_template(ALIAS_SUMMARY_TEMPLATE).render(
+        summary=alias_summary.summary, max=alias_summary.max, 
+        total=alias_summary.total
     )

--- a/cbmc_viewer/templates/alias.jinja.html
+++ b/cbmc_viewer/templates/alias.jinja.html
@@ -1,0 +1,105 @@
+
+<html>
+  <head>
+    <title>CBMC</title>
+    <style>
+      .alias table td
+      {
+        padding-right: 1em; 
+      }
+
+      .alias table th
+      {
+        padding-right: 1em;
+        text-align: left;
+      }
+      .pointsToSett
+      {
+        display: none;
+      }
+      .retainedValuest
+      {
+        display: none;
+      }
+      .valuet
+      {
+        display: none;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>CBMC Pointer Dereference Points-to Set Report</h1>
+    <p>
+      Max points-to set size: {{max}}
+    </p>
+    <p>
+      Total points-to set size: {{total}}
+    </p>
+    <div class="alias">
+      <table class="alias">
+        <tr>
+          <th class="id">Pointer</th>
+          <th class="deref">#Dereference</th>
+          <th class="pointsToSetSize">Points-to Set Size</th>
+          <th class="pointsToSet"><button onclick="toggleButton(0)" id="showPtSet">Show Points-to Set</button></th>
+          <th class="value"><button onclick="toggleButton(2)" id="showExpr">Show Value</button></th>
+        </tr>
+
+          {% for metric in summary.items()|sort(attribute='1.numOfDeref', reverse = True)|sort(attribute='1.PointsToSetSize', reverse=True) %}
+          <tr>
+            <td class="id">{{metric[0]}}</td>
+            <td class="deref">{{metric[1].numOfDeref}}</td>
+            <td class="pointsToSetSize">{{metric[1].PointsToSetSize}}</td>
+            <td class="pointsToSett">{{metric[1].PointsToSet}}</td>
+            <td class="valuet">{{metric[1].Value}}</th>
+          </tr>
+          {% endfor %}
+      </table>
+    </div>
+  </body>
+  <script type="text/javascript">
+    function toggleButton(column){
+      if(column == 0)
+      {
+        var x = document.getElementsByClassName("pointsToSett");
+        var button = document.getElementById("showPtSet");
+      }
+      else if(column == 1)
+      {
+        var x = document.getElementsByClassName("retainedValuest");
+        var button = document.getElementById("showRtVal");
+      }
+      else if(column == 2)
+      {
+        var x = document.getElementsByClassName("valuet");
+        var button = document.getElementById("showExpr");
+      }
+
+      for (elt of x){
+        if(elt.style.display == "none"){
+          elt.style.display = "block";
+          if(column == 0)
+            button.innerHTML = "Hide Points-to Set";
+          else if(column == 1)
+            button.innerHTML = "Hide Retained Values";
+          else if(column == 2)
+            button.innerHTML = "Hide Value";
+          else
+            button.innerHTML = "Hide";
+        }
+        else {
+          elt.style.display = "none";
+          if(column == 0)
+            button.innerHTML = "Show Points-to Set";
+          else if(column == 1)
+            button.innerHTML = "Show Retained Values";
+          else if(column == 2)
+            button.innerHTML = "Show Value";
+          else
+            button.innerHTML = "Show";
+        }
+      }
+    }
+  </script>
+</html>

--- a/cbmc_viewer/viewer.py
+++ b/cbmc_viewer/viewer.py
@@ -10,6 +10,7 @@ and with lists of property violations and traces for each violation.
 
 import argparse
 import datetime
+import json
 import logging
 import os
 
@@ -25,6 +26,9 @@ from cbmc_viewer import sourcet
 from cbmc_viewer import symbolt
 from cbmc_viewer import tracet
 
+# runtime analysis metrics
+from cbmc_viewer import aliast
+
 def create_parser():
     """Create the command line parser."""
 
@@ -39,6 +43,9 @@ def create_parser():
     optionst.result(cbmc_data)
     optionst.coverage(cbmc_data)
     optionst.property(cbmc_data)
+
+    # runtime analysis metrics
+    optionst.alias(cbmc_data)
 
     proof_sources = parser.add_argument_group('Sources')
     optionst.srcdir(proof_sources)
@@ -209,8 +216,16 @@ def viewer():
     dump(symbols, 'viewer-symbol.json')
     progress("Preparing symbol table", True)
 
+    progress("Scanning points-to set data")
+    alias = aliast.AliasSummary(args.alias)
+    alias_obj = {'summary': alias.summary,
+                 'max': alias.max,
+                 'total': alias.total}
+    dump(json.dumps(alias_obj, indent=2), 'viewer-alias.json')
+    progress("Scanning points-to set data", True)
+
     config = configt.Config(args.config)
     report.report(config, sources, symbols, results, coverage, traces,
-                  properties, loops, htmldir, progress)
+                  properties, loops, alias, htmldir, progress)
 
     global_progress("CBMC viewer", True)

--- a/cbmc_viewer/viewer.py
+++ b/cbmc_viewer/viewer.py
@@ -216,13 +216,13 @@ def viewer():
     dump(symbols, 'viewer-symbol.json')
     progress("Preparing symbol table", True)
 
-    progress("Scanning points-to set data")
-    alias = aliast.AliasSummary(args.alias)
-    alias_obj = {'summary': alias.summary,
-                 'max': alias.max,
-                 'total': alias.total}
-    dump(json.dumps(alias_obj, indent=2), 'viewer-alias.json')
-    progress("Scanning points-to set data", True)
+    if args.alias:
+        progress("Scanning points-to set data")
+        alias = aliast.do_make_alias(args.alias)
+        dump(alias, 'viewer-alias.json')
+        progress("Scanning points-to set data", True)
+    else:
+        alias = None
 
     config = configt.Config(args.config)
     report.report(config, sources, symbols, results, coverage, traces,

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setuptools.setup(
             "make-result = cbmc_viewer.make_result:main",
             "make-source = cbmc_viewer.make_source:main",
             "make-symbol = cbmc_viewer.make_symbol:main",
-            "make-trace = cbmc_viewer.make_trace:main"
+            "make-trace = cbmc_viewer.make_trace:main",
+            "make-alias = cbmc_viewer.make_alias:main"
         ]
     }
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Generate pointer alias analysis report using points-to set metric information from CBMC. Takes json output obtained from cbmc --show-points-to-sets and generates a html report describing size and contents of the points-to sets for pointer dereference as recorded by CBMC.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
