### PR TITLE
CBMC runtime analysis: Generate consolidated metric report across multiple proofs

### DIFF
--- a/cbmc_viewer/doc/make-metric-report.md
+++ b/cbmc_viewer/doc/make-metric-report.md
@@ -16,6 +16,7 @@ runtime analysis metric summary report. Output is a html file runtime_analysis_r
 Simple uses of make-coverage are
 
     # Generate all viewer metric data by running cbmc-viewer command
+    # cbmc-viewer --result ....
     make-metric-report --proof proof1 proof2 ... --srcdir /usr/project --reportdir html_report_dir
 
 Type "make-metric-report --help" for a complete list of command line options.

--- a/cbmc_viewer/doc/make-metric-report.md
+++ b/cbmc_viewer/doc/make-metric-report.md
@@ -1,0 +1,21 @@
+# Name
+
+make-metric-report -- generate consolidated runtime analysis metric report
+
+# Synopsis
+
+	usage: make-metric-report [-h] [--srcdir SRCDIR] [--reportdir REPORTDIR]
+                               --proof PROOF [PROOF ...] [--verbose] [--debug]
+
+# Description
+
+This is a front end for the metric_reportt module that viewer uses to scan relevant
+viewer metric json files for multiple proof harnesses and produce a consolidated
+runtime analysis metric summary report. Output is a html file runtime_analysis_report.
+
+Simple uses of make-coverage are
+
+    # Generate all viewer metric data by running cbmc-viewer command
+    make-metric-report --proof proof1 proof2 ... --srcdir /usr/project --reportdir html_report_dir
+
+Type "make-metric-report --help" for a complete list of command line options.

--- a/cbmc_viewer/make_metric_report.py
+++ b/cbmc_viewer/make_metric_report.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# -*- mode: python-mode -*-
+
+"""List CBMC runtime analysis metrics."""
+
+
+import argparse
+import sys
+
+from cbmc_viewer import metric_reportt
+from cbmc_viewer import optionst
+
+def create_parser():
+    """Command line parser."""
+
+    parser = argparse.ArgumentParser(
+        description="List CBMC runtime analysis metrics."
+    )
+
+    optionst.srcdir(parser)
+    optionst.reportdir(parser)
+
+    parser.add_argument(
+        '--proof', '-p',
+        default=[],
+        nargs='+',
+        help="""
+        Provide list of proofs.
+        """,
+        required=True)
+
+    optionst.log(parser)
+
+    return parser
+
+################################################################
+
+def main():
+    """List CBMC runtime analysis metrics."""
+
+    args = create_parser().parse_args()
+    args = optionst.defaults(args)
+
+    try:
+        runtime_analysis = \
+            metric_reportt.RuntimeAnalysisSummary(args.proof,
+                                                  args.srcdir)
+        runtime_analysis.dump(outdir=args.reportdir)
+    except UserWarning as error:
+        sys.exit(error)
+
+if __name__ == "__main__":
+    main()

--- a/cbmc_viewer/make_metric_report.py
+++ b/cbmc_viewer/make_metric_report.py
@@ -21,17 +21,9 @@ def create_parser():
         description="Generate CBMC runtime analysis metrics report."
     )
 
+    optionst.proof(parser)
     optionst.srcdir(parser)
     optionst.reportdir(parser)
-
-    parser.add_argument(
-        '--proof', '-p',
-        default=[],
-        nargs='+',
-        help="""
-        Provide list of proofs.
-        """,
-        required=True)
 
     optionst.log(parser)
 

--- a/cbmc_viewer/make_metric_report.py
+++ b/cbmc_viewer/make_metric_report.py
@@ -5,7 +5,7 @@
 
 # -*- mode: python-mode -*-
 
-"""List CBMC runtime analysis metrics."""
+"""Generate CBMC runtime analysis metrics report."""
 
 
 import argparse
@@ -18,7 +18,7 @@ def create_parser():
     """Command line parser."""
 
     parser = argparse.ArgumentParser(
-        description="List CBMC runtime analysis metrics."
+        description="Generate CBMC runtime analysis metrics report."
     )
 
     optionst.srcdir(parser)
@@ -40,7 +40,7 @@ def create_parser():
 ################################################################
 
 def main():
-    """List CBMC runtime analysis metrics."""
+    """Generate CBMC runtime analysis metrics report."""
 
     args = create_parser().parse_args()
     args = optionst.defaults(args)

--- a/cbmc_viewer/metric_reportt.py
+++ b/cbmc_viewer/metric_reportt.py
@@ -92,13 +92,13 @@ VALID_SUMMARY = voluptuous.schema_builder.Schema({
 
 class RuntimeAnalysisSummary:
 
-    def __init__(self, proofs, srcdir, outdir=None):
+    def __init__(self, proofs, srcdir):
         self.summary = []
 
         for proof in proofs:
             jobname = proof
             proof_path = os.path.abspath(proof)
-            outdir = outdir or os.path.join(proof_path, 'html', 'html')
+            outdir = os.path.join(proof_path, 'html', 'html')
 
             byteop = os.path.join(proof_path, 'html', 'json', 'viewer-byteop.json')
             alias = os.path.join(proof_path, 'html', 'json', 'viewer-alias.json')

--- a/cbmc_viewer/metric_reportt.py
+++ b/cbmc_viewer/metric_reportt.py
@@ -220,13 +220,13 @@ def get_array_stats(file, outdir):
 def get_pattern(key):
     pattern_hash = {
         'programSteps': 'size of program expression: [0-9]+ steps',
-        'vccCount': 'Generated [0-9]+ VCC(s)',
+        'vccCount': 'VCC\(s\), [0-9]+ remaining',
         'varCount': '[0-9]+ variables',
         'clauseCount': '[0-9]+ clauses',
         'symex': 'Runtime Symex: [0-9.]+',
         'convertSSA': 'Runtime Convert SSA: [0-9.]+',
         'postProc': 'Runtime Post-process: [0-9.]+',
-        'solver': 'Runtime solver: [0-9.]+'
+        'solver': 'Runtime Solver: [0-9.]+'
     }
 
     return pattern_hash[key]
@@ -272,7 +272,7 @@ def get_cbmc_proof_stats(file):
         for key in cbmc.keys():
             count, match = cbmc_proof_stats_pattern_match(key, line)
             if match:
-                cbmc[key] = count
+                cbmc[key] += count
 
                 if key == 'varCount':
                     continue
@@ -344,7 +344,7 @@ def get_cbmc_runtime_stats(file):
         for key in runtime.keys():
             time, match = cbmc_runtime_pattern_match(key, line)
             if match:
-                runtime[key]['val'] = time
+                runtime[key]['val'] += time
                 continue
 
     runtime_val = dict({key:runtime[key]['val'] for key in runtime.keys()})

--- a/cbmc_viewer/metric_reportt.py
+++ b/cbmc_viewer/metric_reportt.py
@@ -345,7 +345,7 @@ def get_cbmc_runtime_stats(file):
             time, match = cbmc_runtime_pattern_match(key, line)
             if match:
                 runtime[key]['val'] += time
-                continue
+                break
 
     runtime_val = dict({key:runtime[key]['val'] for key in runtime.keys()})
 

--- a/cbmc_viewer/metric_reportt.py
+++ b/cbmc_viewer/metric_reportt.py
@@ -1,0 +1,401 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CBMC runtime analysis metric report.
+
+This module collects all metric data across multiple proofs and
+generates a single consolidated metric summary report./
+"""
+
+import os
+import re
+import json
+
+import voluptuous
+import voluptuous.humanize
+
+from cbmc_viewer import filet
+from cbmc_viewer import parse
+from cbmc_viewer import templates
+from cbmc_viewer import util
+
+################################################################
+
+VALID_BYTEOP_STATS = voluptuous.schema_builder.Schema({
+    'numOfExtracts': int,
+    'numOfUpdates': int,
+    'link': str
+    },required=True)
+
+VALID_ALIAS_STATS = voluptuous.schema_builder.Schema({
+    'max': int,
+    'total': int,
+    'link': str
+    },required=True)
+
+VALID_MEMOP_STATS = voluptuous.schema_builder.Schema({
+    'count': int,
+    'link': str
+    },required=True)
+
+VALID_ARRAY_CONSTRAINT_STATS = voluptuous.schema_builder.Schema({
+    'count': int,
+    'link': str
+    },required=True)
+
+VALID_CBMC_PROOF_STATS = voluptuous.schema_builder.Schema({
+    'programSteps': int,
+    'vccCount': int,
+    'varCount': int,
+    'clauseCount': int
+    },required=True)
+
+VALID_CLAUSE_STATS = voluptuous.schema_builder.Schema({
+    'clauseCoreCount': int,
+    'link': str
+    },required=True)
+
+VALID_RUNTIME_OBJ = voluptuous.schema_builder.Schema({
+    'val': float,
+    'string': str
+    },required=True)
+
+VALID_RUNTIME = voluptuous.schema_builder.Schema({
+    'symex': VALID_RUNTIME_OBJ,
+    'convertSSA': VALID_RUNTIME_OBJ,
+    'postProc': VALID_RUNTIME_OBJ,
+    'solver': VALID_RUNTIME_OBJ,
+    'maxKey': {
+        'val': str,
+        'string': str
+        }
+    },required=True)
+
+VALID_RUNTIME_ANALYSIS_SUMMARY = voluptuous.schema_builder.Schema([{
+    'jobname': str,
+    'link': str,
+    'byteop': VALID_BYTEOP_STATS,
+    'alias': VALID_ALIAS_STATS,
+    'memop': VALID_MEMOP_STATS,
+    'array': VALID_ARRAY_CONSTRAINT_STATS,
+    'cbmc': VALID_CBMC_PROOF_STATS,
+    'clause': VALID_CLAUSE_STATS,
+    'runtimeKissat': float,
+    'runtime': VALID_RUNTIME
+    }],required=True)
+
+VALID_SUMMARY = voluptuous.schema_builder.Schema({
+    'summary': VALID_RUNTIME_ANALYSIS_SUMMARY
+    },required=True)
+
+################################################################
+
+class RuntimeAnalysisSummary:
+
+    def __init__(self, proofs, srcdir, outdir=None):
+        self.summary = []
+
+        for proof in proofs:
+            jobname = proof
+            proof_path = os.path.abspath(proof)
+            outdir = outdir or os.path.join(proof_path, 'html', 'html')
+
+            byteop = os.path.join(proof_path, 'html', 'json', 'viewer-byteop.json')
+            alias = os.path.join(proof_path, 'html', 'json', 'viewer-alias.json')
+            memop = os.path.join(proof_path, 'html', 'json', 'viewer-memop.json')
+            array = os.path.join(proof_path, 'html', 'json', 'viewer-array.json')
+            result = os.path.join(proof_path, 'html', 'json', 'viewer-result.json')
+            clause = os.path.join(proof_path, 'html', 'json', 'viewer-core.json')
+            kissat = os.path.join(proof_path, 'logs', 'kissat.txt')
+            
+            self.summary.append({
+                'jobname': jobname,
+                'link': get_link_to_job(outdir),
+                'byteop': get_byteop_stats(byteop, outdir),
+                'alias': get_alias_stats(alias, outdir),
+                'memop': get_memop_stats(memop, outdir),
+                'array': get_array_stats(array, outdir),
+                'cbmc': get_cbmc_proof_stats(result),
+                'clause': get_clause_stats(clause, outdir),
+                'runtimeKissat': get_kissat_runtime(kissat),
+                'runtime': get_cbmc_runtime_stats(result)
+                })
+
+        self.validate()
+
+
+    def __str__(self):
+        """Render the byte op summary as html."""
+        return templates.render_runtime_analysis_summary(self.summary)
+
+    def validate(self):
+        """Validate members of a summary object."""
+
+        return voluptuous.humanize.validate_with_humanized_errors(
+            self.__dict__, VALID_SUMMARY
+        )
+
+    def dump(self, filename=None, outdir='.'):
+        """Write the proof summary to a file rendered as html."""
+
+        util.dump(self, filename or "runtime_analysis_report.html", outdir)
+
+################################################################
+# Utility functions to generate runtime analysis summary
+
+def get_link(outdir, metric):
+    return '<a href="{}/{}.html">'.format(outdir, metric)
+
+def get_link_to_job(outdir):
+    return get_link(outdir, 'index')
+
+def fail(msg):
+    """Log failure and raise exception."""
+
+    logging.info(msg)
+    raise UserWarning(msg)
+
+def get_byteop_stats(file, outdir):
+    byteop_link = get_link(outdir, 'byteop')
+
+    if not filet.is_json_file(file):
+        fail("Expected json file: {}"
+            .format(file))
+
+    json_data = parse.parse_json_file(file)
+    byteop = {
+        'numOfExtracts': json_data['numOfExtracts'],
+        'numOfUpdates': json_data['numOfUpdates'],
+        'link': byteop_link
+    }
+
+    return byteop
+
+def get_alias_stats(file, outdir):
+    alias_link = get_link(outdir, 'alias')
+
+    if not filet.is_json_file(file):
+        fail("Expected json file: {}"
+            .format(file))
+
+    json_data = parse.parse_json_file(file)
+    alias = {
+        'max': json_data['max'],
+        'total': json_data['total'],
+        'link': alias_link
+    }
+
+    return alias
+
+def get_memop_stats(file, outdir):
+    memop_link = get_link(outdir, 'memop')
+
+    if not filet.is_json_file(file):
+        fail("Expected json file: {}"
+            .format(file))
+
+    json_data = parse.parse_json_file(file)
+    memop = {
+        'count': json_data['count'],
+        'link': memop_link
+    }
+
+    return memop
+
+def get_array_stats(file, outdir):
+    array_link = get_link(outdir, 'array')
+
+    if not filet.is_json_file(file):
+        fail("Expected json file: {}"
+            .format(file))
+
+    json_data = parse.parse_json_file(file)
+    array = {
+        'count': json_data['numOfConstraints'],
+        'link': array_link
+    }
+
+    return array
+
+def get_pattern(key):
+    pattern_hash = {
+        'programSteps': 'size of program expression: [0-9]+ steps',
+        'vccCount': 'Generated [0-9]+ VCC(s)',
+        'varCount': '[0-9]+ variables',
+        'clauseCount': '[0-9]+ clauses',
+        'symex': 'Runtime Symex: [0-9.]+',
+        'convertSSA': 'Runtime Convert SSA: [0-9.]+',
+        'postProc': 'Runtime Post-process: [0-9.]+',
+        'solver': 'Runtime solver: [0-9.]+'
+    }
+
+    return pattern_hash[key]
+
+def cbmc_proof_stats_pattern_match(key, string):
+    pattern = get_pattern(key)
+
+    pattern_match = re.search(pattern, string)
+    if pattern_match:
+        count_match = re.search('[0-9]+', pattern_match.group(0))
+        if count_match:
+            count = count_match.group(0)
+            return int(count), True
+    return None, False
+
+def cbmc_runtime_pattern_match(key, string):
+    pattern = get_pattern(key)
+
+    pattern_match = re.search(pattern, string)
+    if pattern_match:
+        time_match = re.search('[0-9.]+', pattern_match.group(0))
+        if time_match:
+            time = time_match.group(0)
+            return float(time), True
+    return None, False
+
+def get_cbmc_proof_stats(file):
+    if not filet.is_json_file(file):
+        fail("Expected json file: {}"
+            .format(file))
+
+    json_data = parse.parse_json_file(file)
+    result = json_data['viewer-result']['status']
+
+    cbmc = {
+        'programSteps': 0,
+        'vccCount': 0,
+        'varCount': 0,
+        'clauseCount': 0
+    }
+
+    for line in result:
+        for key in cbmc.keys():
+            count, match = cbmc_proof_stats_pattern_match(key, line)
+            if match:
+                cbmc[key] = count
+
+                if key == 'varCount':
+                    continue
+                else:
+                    break
+
+    return cbmc
+
+def get_clause_stats(file, outdir):
+    clause_link = get_link(outdir, 'clause')
+
+    if not filet.is_json_file(file):
+        fail("Expected json file: {}"
+            .format(file))
+
+    json_data = parse.parse_json_file(file)
+    clause = {
+        'clauseCoreCount': json_data['numOfClauses'],
+        'link': clause_link
+    }
+
+    return clause
+
+def get_kissat_runtime(file):
+
+    if not filet.is_text_file(file):
+        fail("Expected text file: {}"
+            .format(file))
+        
+    with open(file) as f:
+        for line in f.readlines():
+            pattern = re.search('c process-time:.*[0-9.]+ seconds',line)
+            if pattern:
+                time_pat = re.search('[0-9.]+ seconds', pattern.group(0))
+                time_pat = re.search('[0-9.]+', time_pat.group(0))
+                if time_pat:
+                    time = time_pat.group(0)
+                    return float(time)
+    return None
+
+def get_cbmc_runtime_stats(file):
+    if not filet.is_json_file(file):
+        fail("Expected json file: {}"
+            .format(file))
+
+    json_data = parse.parse_json_file(file)
+    result = json_data['viewer-result']['status']
+
+    runtime = {
+        'symex': {
+            'val': 0.0,
+            'string': "Symex"
+            },
+        'convertSSA': {
+            'val': 0.0,
+            'string': "SSA To SAT"
+            },
+        'postProc': {
+            'val': 0.0,
+            'string': "Post Processing"
+            },
+        'solver': {
+            'val': 0.0,
+            'string': "Solver"
+            }
+        }
+
+    for line in result:
+        for key in runtime.keys():
+            time, match = cbmc_runtime_pattern_match(key, line)
+            if match:
+                runtime[key]['val'] = time
+                continue
+
+    runtime_val = dict({key:runtime[key]['val'] for key in runtime.keys()})
+
+    max_key = max(runtime_val, key=runtime_val.get)
+    runtime['maxKey'] = {}
+    runtime['maxKey']['val'] = max_key
+    runtime['maxKey']['string'] = "Max Runtime Stage"
+
+    return runtime
+
+def create_parser():
+
+    parser = argparse.ArgumentParser(
+        description='Report CBMC results.'
+    )
+
+    parser.add_argument(
+        '--json_files',
+        default=[],
+        nargs='+',
+        help="""
+        Provide list of json files.
+        """,
+        required=True)
+
+    parser.add_argument(
+        '--srcdir',
+        help="""
+        Project root directory.
+        """,
+        required=True)
+
+    parser.add_argument(
+        '--outdir',
+        help="""
+        Project output directory.
+        """,
+        required=True)
+
+    return parser
+
+def main():
+
+    args = create_parser().parse_args()
+
+    json_files = args.json_files
+    srcdir = args.srcdir
+    outdir = args.outdir
+
+    RuntimeAnalysisSummary(json_files, srcdir).dump(outdir=outdir)
+
+if __name__ == '__main__':
+    main()

--- a/cbmc_viewer/optionst.py
+++ b/cbmc_viewer/optionst.py
@@ -114,6 +114,19 @@ def property(parser):
     )
     return parser
 
+def proof(parser):
+    'Define --proof command line option.'
+
+    parser.add_argument(
+        '--proof', '-p',
+        default=[],
+        nargs='+',
+        help="""
+        Provide list of proofs.
+        """
+    )
+    return parser
+
 def exclude(parser):
     'Define --exclude command line option.'
 

--- a/cbmc_viewer/templates.py
+++ b/cbmc_viewer/templates.py
@@ -14,6 +14,9 @@ SUMMARY_TEMPLATE = 'summary.jinja.html'
 CODE_TEMPLATE = 'code.jinja.html'
 TRACE_TEMPLATE = 'trace.jinja.html'
 
+# runtime analysis metrics
+RUNTIME_ANALYSIS_SUMMARY_TEMPLATE = 'runtime_analysis_report.jinja.html'
+
 ENV = None
 
 def env():
@@ -48,4 +51,11 @@ def render_trace(name, desc, srcloc, steps):
 
     return env().get_template(TRACE_TEMPLATE).render(
         prop_name=name, prop_desc=desc, prop_srcloc=srcloc, steps=steps
+    )
+
+def render_runtime_analysis_summary(runtime_analysis_summary):
+    """Render runtime analysis summary as html."""
+
+    return env().get_template(RUNTIME_ANALYSIS_SUMMARY_TEMPLATE).render(
+        summary=runtime_analysis_summary
     )

--- a/cbmc_viewer/templates/runtime_analysis_report.jinja.html
+++ b/cbmc_viewer/templates/runtime_analysis_report.jinja.html
@@ -1,0 +1,106 @@
+
+<html>
+  <head>
+    <title>CBMC</title>
+    <style>
+      .metric table td
+      {
+        padding-right: 1em; 
+      }
+
+      .metric table td:not(.job):not(.maxKey)
+      {
+        text-align: right;
+      }
+
+      .metric table th
+      {
+        padding-right: 1em;
+        text-align: left;
+      }
+
+      td: not(.job)
+      {
+        text-align: right;
+      }
+      mark 
+      {
+        background-color: #AFF8DB;
+        color: black;
+      }
+    </style>
+  </head>
+
+  <body>
+    <h1>CBMC Runtime Analysis Report</h1>
+
+    <div class="metric">
+      <table class="metric">
+        <tr>
+          <th class="job">Job Name</th>
+          <th class="numofExtracts">#Extracts</th>
+          <th class="numOfUpdates">#Updates</th>
+          <th class="aliasMax">Max size<br>(points-to-set)</th>
+          <th class="aliasTotal">Total size<br>(points-to-set)</th>
+          <th class="memOpCount">#MemOp</th>
+          <th class="arrayConstraintCount">#ArrayConstraints</th>
+          <th class="programSteps">Program Steps</th>
+          <th class="vccCount">#VCC</th>
+          <th class="varCount">#Variables</th>
+          <th class="clauseCount">#Clauses</th>
+          <th class="clauseCoreCount">#CoreClauses</th>
+          <th class="clauseCorePercent">%CoreClauses</th>
+          <th class="runtimeKissat">Kissat Runtime</th>
+          {% set metric = summary[0] %}
+            {% for key in metric.runtime.keys() %}
+              <th class={{key}}>{{metric.runtime[key].string}}</th>
+            {% endfor %}
+        </tr>
+
+        {% for metric in summary|sort(attribute="runtime.solver.val", reverse = True) %}
+        <tr>
+          <td class="job">{{metric.link}}{{metric.jobname}}</a></td>
+          {% set byteop = metric.byteop %}
+            <td class="numofExtracts">{{byteop.link}}{{byteop.numOfExtracts}}</td>
+            <td class="numOfUpdates">{{byteop.link}}{{byteop.numOfUpdates}}</td>
+
+          {% set alias = metric.alias %}
+            <td class="aliasMax">{{alias.link}}{{alias.max}}</td>
+            <td class="aliasTotal">{{alias.link}}{{alias.total}}</td>
+
+          {% set memop = metric.memop %}
+            <td class="memOpCount">{{memop.link}}{{memop.count}}</td>
+
+          {% set array = metric.array %}
+            <td class="arrayConstraintCount">{{array.link}}{{array.count}}</td>
+
+          {% set cbmc = metric.cbmc %}
+            <td class="programSteps">{{cbmc.programSteps}}</td>
+            <td class="vccCount">{{cbmc.vccCount}}</td>
+            <td class="varCount">{{cbmc.varCount}}</td>
+            <td class="clauseCount">{{cbmc.clauseCount}}</a></td>
+
+          {% set clause = metric.clause %}
+            <td class="clauseCoreCount">{{clause.link}}{{clause.clauseCoreCount}}</a></td>
+            {% if cbmc.clauseCount != 0 %}
+              <td class="clauseCorePercent">{{'%0.2f' % (clause.clauseCoreCount/cbmc.clauseCount * 100) | float }}%</a></td>
+            {% else %}
+              <td class="clauseCorePercent">-</a></td>
+            {% endif %}
+
+          <td class="runtimeKissat">{{metric.runtimeKissat}}</td>
+            
+          {% set runtime = metric.runtime %}
+            {% for key in runtime.keys() %}
+              {% if key != "maxKey" %}
+                <td class={{key}}>{{'%0.2f' % runtime[key].val | float}}</td>
+              {% else %}
+                <td class={{key}}>{{runtime[key].val}}</td>
+              {% endif %}
+            {% endfor %}
+          </tr>
+        {% endfor %}
+      </table>
+    </div>
+  </body>
+</html>

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,8 @@ setuptools.setup(
             "make-result = cbmc_viewer.make_result:main",
             "make-source = cbmc_viewer.make_source:main",
             "make-symbol = cbmc_viewer.make_symbol:main",
-            "make-trace = cbmc_viewer.make_trace:main"
+            "make-trace = cbmc_viewer.make_trace:main",
+            "make-metric-report = cbmc_viewer.make_metric_report:main"
         ]
     }
 )


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add metric-report module to read viewer json logs and generate a consolidated runtime analysis report across multiple proofs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
