### PR TITLE
Restrict coverage data to coverage of reachable functions

### DIFF
--- a/cbmc_viewer/make_coverage.py
+++ b/cbmc_viewer/make_coverage.py
@@ -33,7 +33,7 @@ def create_parser():
         Do not mix xml and json files.
         """
     )
-
+    optionst.viewer_reachable(parser)
     optionst.log(parser)
 
     return parser
@@ -49,7 +49,9 @@ def main():
     try:
         coverage = coveraget.do_make_coverage(args.viewer_coverage,
                                               args.srcdir,
-                                              args.cbmc_coverage)
+                                              args.cbmc_coverage,
+                                              args.viewer_reachable
+                                              )
         print(coverage)
     except UserWarning as error:
         sys.exit(error)

--- a/cbmc_viewer/srcloct.py
+++ b/cbmc_viewer/srcloct.py
@@ -125,7 +125,8 @@ def make_srcloc(path, func, line, wkdir, root):
     """Make a viewer source location from a CBMC source location."""
 
     if path is None or line is None:
-        logging.info("Generating a viewer srcloc for a missing CBMC srcloc.")
+        logging.info("Generating a viewer srcloc for a missing CBMC srcloc: %s %s %s",
+                     path, func, line)
         return MISSING_SRCLOC
 
     path = normpath(path)

--- a/cbmc_viewer/viewer.py
+++ b/cbmc_viewer/viewer.py
@@ -149,8 +149,18 @@ def viewer():
     os.makedirs(jsondir, exist_ok=True)
 
     def dump(obj, name):
-        with open(os.path.join(jsondir, name), 'w') as output:
+        path = os.path.join(jsondir, name)
+        with open(path, 'w') as output:
             output.write(str(obj))
+        return path
+
+    progress("Computing reachable functions")
+    reachable = reachablet.do_make_reachable(args.viewer_reachable,
+                                             None,
+                                             args.srcdir,
+                                             args.goto)
+    viewer_reachable = dump(reachable, 'viewer-reachable.json')
+    progress("Computing reachable functions", True)
 
     progress("Scanning property checking results")
     results = resultt.do_make_result(args.viewer_result, args.result)
@@ -166,7 +176,8 @@ def viewer():
     progress("Scanning coverage data")
     coverage = coveraget.do_make_coverage(args.viewer_coverage,
                                           args.srcdir,
-                                          args.coverage)
+                                          args.coverage,
+                                          [viewer_reachable])
     dump(coverage, 'viewer-coverage.json')
     progress("Scanning coverage data", True)
 
@@ -182,14 +193,6 @@ def viewer():
                                             args.srcdir)
     dump(properties, 'viewer-property.json')
     progress("Scanning properties", True)
-
-    progress("Computing reachable functions")
-    reachable = reachablet.do_make_reachable(args.viewer_reachable,
-                                             None,
-                                             args.srcdir,
-                                             args.goto)
-    dump(reachable, 'viewer-reachable.json')
-    progress("Computing reachable functions", True)
 
     # Make sources last, it may delete the goto binary
     progress("Scanning source tree")


### PR DESCRIPTION
This pull request restricts the coverage calculation and reporting to those functions cbmc considers reachable functions (and not just all functions appearing in the goto binary).

This requires
1. Adding the set of reachable functions as an optional parameter to the constructors for the various coverage classes (that extract coverage data from the various sources, like xml versus json coverage data).
2. Moving the computation of reachable functions in the main viewer code to before the computation of the coverage data, and noting the path to the file json file that contains the reachable functions.
3. Writing a function to filter the coverage data down to the the coverage data for the reachable functions.  In the process, we wrote a sanity-checking predicate to confirm that coverage data reports no reachable lines in unreachable functions, and that we have some coverage data for each reachable function.
