### PR TITLE
Refactor result parsing

### DIFF
--- a/cbmc_viewer/resultt.py
+++ b/cbmc_viewer/resultt.py
@@ -1,29 +1,25 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""CBMC property checking results.
+"""CBMC property checking results."""
 
-The Result module describes the results of CBMC property checking, the
-Coverage module describes the results of CBMC coverage checking, and
-the Property module describes the properties checked during property
-checking.
-"""
-
-import re
 import json
 import logging
+import re
 
-import voluptuous
+from voluptuous import Schema, Any
 import voluptuous.humanize
 
 from cbmc_viewer import filet
 from cbmc_viewer import parse
 from cbmc_viewer import propertyt
 from cbmc_viewer import util
+from cbmc_viewer.util import flatten, choose
 
 JSON_TAG = 'viewer-result'
 
 ################################################################
+# Validator for property checking results
 
 PROGRAM = 'program'
 STATUS = 'status'
@@ -33,73 +29,64 @@ PROVER = 'prover'
 FAILURE = 'failure'
 SUCCESS = 'success'
 
-################################################################
-# Property checking results validator
-
-VALID_RESULT = voluptuous.Schema({
-    PROGRAM: str,     # program version information
-    STATUS: [str],    # list of status messages
-    WARNING: [str],   # list of warning messages
+VALID_RESULT = Schema({
+    PROGRAM: Any(str, None), # program version string
+    STATUS: [str],           # list of status messages
+    WARNING: [str],          # list of warning messages
     RESULT: {
-        True : [str], # list of proved assertions
-        False: [str]  # list of failed assertions
+        True : [str],        # list of proved assertions
+        False: [str]         # list of failed assertions
     },
-    PROVER: str       # prover status: success or failure
+    PROVER: Any(FAILURE, SUCCESS, None) # prover status: success or failure
 }, required=True)
 
-NO_RESULT = {
-    PROGRAM: "",
+EMPTY_RESULT = {
+    PROGRAM: None,
     STATUS: [],
     WARNING: [],
     RESULT: {
         True: [],
         False: [],
     },
-    PROVER: FAILURE
+    PROVER: None
 }
 
 ################################################################
 # CBMC property checking results
 
 class Result:
-    """CBMC property checking results.
-
-    Given a list of property checking results (dict representations of
-    the Result object) merge the list of results into a single set of
-    results.
-    """
+    """CBMC property checking results."""
 
     def __init__(self, results_list=None):
-        results_list = results_list or [NO_RESULT]
+        """Merge a list of results into a single result.
 
-        map(lambda results: results.validate(), results_list)
-        self.program = self.flatten_string_list(
-            [results[PROGRAM] for results in results_list]
-        )
-        self.status = self.flatten_string_list_list(
-            [results[STATUS] for results in results_list]
-        )
-        self.warning = self.flatten_string_list_list(
-            [results[WARNING] for results in results_list]
-        )
-        self.results = self.flatten_results_list(
-            [results[RESULT] for results in results_list]
-        )
-        self.prover = self.flatten_prover_list(
-            [results[PROVER] for results in results_list]
-        )
+        Each result is given by the dict representation of a result object.
+        """
+
+        results_list = results_list or [EMPTY_RESULT]
+        for results in results_list:
+            self.validate(results)
+
+        self.program = choose([results[PROGRAM] for results in results_list])
+        self.status = flatten([results[STATUS] for results in results_list])
+        self.warning = flatten([results[WARNING] for results in results_list])
+
+        success = set(flatten([results[RESULT][True] for results in results_list]))
+        failure = set(flatten([results[RESULT][False] for results in results_list]))
+        self.results = {
+            True: sorted(success.difference(failure), key=propertyt.key),
+            False: sorted(failure, key=propertyt.key)
+        }
+
+        status = [results[PROVER] for results in results_list] or [None]
+        self.prover = None if None in status else FAILURE if FAILURE in status else SUCCESS
         self.validate()
 
     def __repr__(self):
         """A dict representation of results."""
 
-        results = self.__dict__
-        success = sorted(results['results'][True], key=propertyt.key)
-        failure = sorted(results['results'][False], key=propertyt.key)
-        results['results'][True] = success
-        results['results'][False] = failure
-        self.validate(results)
-        return results
+        self.validate()
+        return self.__dict__
 
     def __str__(self):
         """A string representation of results."""
@@ -118,77 +105,11 @@ class Result:
 
         util.dump(self, filename, directory)
 
-    @staticmethod
-    def flatten_string_list(string_list):
-        """Extract a string from a list of strings (expect a unique string)"""
-
-        if not string_list:
-            return None
-        if len(string_list) == 1:
-            return string_list[0]
-
-        strings = set(string_list)
-        strings.discard(None)
-
-        if not strings:
-            return None
-        if len(strings) == 1:
-            return strings.pop()
-
-        logging.info('Expected a unique string (%s), found %s strings',
-                     strings.pop(), len(strings))
-        return strings.pop()
-
-    @staticmethod
-    def flatten_string_list_list(string_list_list):
-        """Flatten a list of string lists into a single string list"""
-
-        if not string_list_list:
-            return None
-        if len(string_list_list) == 1:
-            return [elt for elt in string_list_list[0] if elt]
-
-        return [elt
-                for string_list in string_list_list if string_list
-                for elt in string_list if elt]
-
-    @staticmethod
-    def flatten_results_list(results_list):
-        """Flatten a list of verfication results into a single list"""
-
-        if not results_list:
-            return None
-        if len(results_list) == 1:
-            return results_list[0]
-
-        # We are assuming assertion names are consistent across proofs
-        success = {name
-                   for results in results_list
-                   for name in results[True]}
-        failure = {name
-                   for results in results_list
-                   for name in results[False]}
-        success = success.difference(failure)
-
-        return {True: list(success), False: list(failure)}
-
-    @staticmethod
-    def flatten_prover_list(prover_list):
-        """Combine a list of prover success/failure results into one result"""
-
-        results = {result.lower() for result in prover_list}
-        if FAILURE in results:
-            return FAILURE
-        if SUCCESS in results:
-            return SUCCESS
-        raise UserWarning('Expected {} or {} in prover results, '
-                          'found {}'.format(SUCCESS, FAILURE, results))
-
 ################################################################
-# CBMC property checking results from make-result
+# CBMC property checking results loaded from make-result json data
 
 class ResultFromJson(Result):
-    """CBMC property checking results from make-result"""
+    """CBMC property checking results loaded from make-result json data"""
 
     def __init__(self, json_files):
         super().__init__(
@@ -199,89 +120,164 @@ class ResultFromJson(Result):
     def load_results(json_file):
         """Load CBMC results from json file"""
 
-        data = parse.parse_json_file(json_file)[JSON_TAG]
+        blob = parse.parse_json_file(json_file)[JSON_TAG]
 
         # json uses strings "true" and "false" for True and False keys
-        data[RESULT][True] = data[RESULT]["true"]
-        data[RESULT][False] = data[RESULT]["false"]
-        del data[RESULT]["true"]
-        del data[RESULT]["false"]
+        blob[RESULT][True] = blob[RESULT]["true"]
+        blob[RESULT][False] = blob[RESULT]["false"]
+        del blob[RESULT]["true"]
+        del blob[RESULT]["false"]
 
-        return data
+        return blob
 
 ################################################################
-# CBMC property checking results from cbmc text output
+# CBMC property checking results loaded from cbmc text output
 
 class ResultFromCbmcText(Result):
-    """CBMC property checking results from CBMC text output"""
+    """CBMC property checking results loaded from cbmc text output"""
 
     def __init__(self, text_files):
         super().__init__(
-            [self.parse_results(text_file) for text_file in text_files]
+            [parse_cbmc_text_results(text_file) for text_file in text_files]
         )
 
-    @staticmethod
-    def parse_results(textfile):
-        """Parse CBMC results in text output"""
+################################################################
+# CBMC property checking results loaded from cbmc json output
 
-        # Using --verbosity 4 omits the program version data in
-        # textual output, so default to "CBMC" in case it is missing.
-        results = {
-            PROGRAM: "CBMC", STATUS: [], WARNING: [],
-            RESULT: {True: [], False: []}, PROVER: None
-        }
+class ResultFromCbmcJson(Result):
+    """CBMC property checking results loaded from cbmc json output"""
 
-        # TODO: handle cbmc --stop-on-fail text output
-        section = None
-        with open(textfile) as data:
-            for line in data:
-                line = line.strip()
-                if not line:
-                    continue
-                if line.startswith('CBMC version'):
-                    results[STATUS].append(line)
-                    results[PROGRAM] = line
-                    continue
-                if line.startswith('**** WARNING:'):
-                    results[WARNING].append(line)
-                    continue
-                if line == 'VERIFICATION FAILED':
-                    results[STATUS].append(line)
-                    results[PROVER] = FAILURE
-                    continue
-                if line == 'VERIFICATION SUCCESSFUL':
-                    results[STATUS].append(line)
-                    results[PROVER] = SUCCESS
-                    continue
-                if line.startswith('** Results:'):
-                    section = 'result'
-                    continue
-                if line.startswith('Trace for '):
-                    section = 'trace'
-                    # trace module collects traces
-                    continue
-                if section == 'result':
-                    # The nonempty lines of the results section have the form
-                    #   [name] srcloc description: SUCCESS|FAILURE
-                    # but the srcloc may be missing or incomplete in inconsistent ways
-                    match = re.match(
-                        r'\[([^\]]*)\].*: ((FAILURE)|(SUCCESS))',
-                        line)
-                    if match:
-                        name = match.group(1)
-                        status = match.group(2)
-                        success = status == 'SUCCESS'
-                        results[RESULT][success].append(name)
-                    continue
-                if section == 'trace':
-                    # trace module collects traces
-                    continue
-                results[STATUS].append(line)
-
-        return results
+    def __init__(self, json_files):
+        super().__init__(
+            [parse_cbmc_json_results(json_file) for json_file in json_files]
+        )
 
 ################################################################
-# CBMC property checking results from cbmc json output
+# CBMC property checking results loaded from cbmc xml output
+
+class ResultFromCbmcXml(Result):
+    """CBMC property checking results loaded from CBMC xml output"""
+
+    def __init__(self, xml_files):
+        super().__init__(
+            [parse_cbmc_xml_results(xml_file) for xml_file in xml_files]
+        )
+
+################################################################
+# Parse the text output of cbmc property checking into sections
+#
+# This parsing is required only for text output of cbmc.  The text
+# output is just an unstructured sequence of lines with embedded
+# section headers.  The json and xml output of cbmc are already
+# structured into sections, and sections are easy to find.
+
+LOG_SECTION = 'log'
+RESULTS_SECTION = 'results'
+TRACES_SECTION = 'traces'
+SUMMARY_SECTION = 'summary'
+
+EMPTY_SECTIONS = {
+    LOG_SECTION: [],
+    RESULTS_SECTION: [],
+    TRACES_SECTION: [],
+    SUMMARY_SECTION: []
+}
+
+RESULTS_SECTION_HEADER = "** Results"
+TRACES_SECTION_HEADER = "Trace for"
+SUMMARY_SECTION_HEADER = "** " # Caution: summary header is a prefix of results header
+
+def cbmc_text_sections(text_file):
+    """Parse the text output of cbmc property checking into sections"""
+
+    sections = EMPTY_SECTIONS
+    with open(text_file, encoding='utf-8') as blob:
+        # The blob is an iterator that iterates through the lines of
+        # the file and throws StopIteration at the end of the file.
+        next_line = lambda : next(blob).rstrip()
+        try:
+            line = next_line()
+
+            # Log section is from here to results section
+            while not line.startswith(RESULTS_SECTION_HEADER):
+                sections[LOG_SECTION].append(line)
+                line = next_line()
+
+            # Results section is from here to traces section or summary section
+            # Traces section is optional: generated by `cbmc --trace`
+            line = next_line() # skip results header
+            while (not line.startswith(TRACES_SECTION_HEADER) and
+                   not line.startswith(SUMMARY_SECTION_HEADER)):
+                sections[RESULTS_SECTION].append(line)
+                line = next_line()
+
+            # Traces section is from here to summary section
+            # Traces section is optional: generated by `cbmc --trace`
+            if line.startswith(TRACES_SECTION_HEADER):
+                while not line.startswith(SUMMARY_SECTION_HEADER):
+                    sections[TRACES_SECTION].append(line)
+                    line = next_line()
+
+            # Summary section is from here to end of file
+            while True:
+                sections[SUMMARY_SECTION].append(line)
+                line = next_line()
+        except StopIteration:
+            return sections
+
+################################################################
+# Parse cbmc property checking output
+
+def parse_cbmc_text_results(text_file):
+    """Parse text output of cbmc property checking"""
+
+    try:
+        sections = cbmc_text_sections(text_file)
+    except OSError as error:
+        raise UserWarning(f"Can't parse {text_file}: {str(error)}") from error
+
+    results = EMPTY_RESULT
+    results[PROGRAM] = cbmc_text_program(sections[LOG_SECTION])
+    results[STATUS] = cbmc_text_status(sections[LOG_SECTION], sections[SUMMARY_SECTION])
+    results[WARNING] = cbmc_text_warnings(sections[LOG_SECTION])
+    results[RESULT] = cbmc_text_results(sections[RESULTS_SECTION])
+    results[PROVER] = cbmc_text_prover(sections[SUMMARY_SECTION])
+
+    return results
+
+def parse_cbmc_json_results(json_file):
+    """Parse json output of cbmc property checking"""
+
+    blob = parse.parse_json_file(json_file)
+    if blob is None:
+        return EMPTY_RESULT
+
+    results = EMPTY_RESULT
+    results[PROGRAM] = cbmc_json_program(blob)
+    results[STATUS] = cbmc_json_status(blob)
+    results[WARNING] = cbmc_json_warnings(blob)
+    results[RESULT] = cbmc_json_results(blob)
+    results[PROVER] = cbmc_json_prover(blob)
+
+    return results
+
+def parse_cbmc_xml_results(xml_file):
+    """Parse xml output of cbmc property checking"""
+
+    blob = parse.parse_xml_file(xml_file)
+    if blob is None:
+        return EMPTY_RESULT
+
+    results = EMPTY_RESULT
+    results[PROGRAM] = cbmc_xml_program(blob)
+    results[STATUS] = cbmc_xml_status(blob)
+    results[WARNING] = cbmc_xml_warnings(blob)
+    results[RESULT] = cbmc_xml_results(blob)
+    results[PROVER] = cbmc_xml_prover(blob)
+
+    return results
+
+# Keys used in cbmc json output
 
 JSON_DESCRIPTION_KEY = 'description'
 JSON_MESSAGE_TEXT_KEY = 'messageText'
@@ -296,141 +292,216 @@ JSON_STATUS_MESSAGE = 'STATUS-MESSAGE'
 JSON_SUCCESS = 'SUCCESS'
 JSON_WARNING = 'WARNING'
 
-class ResultFromCbmcJson(Result):
-    """CBMC property checking results from CBMC json output"""
+JSON_PROVER_STATUS_SUCCESS = 'success'
 
-    def __init__(self, json_files):
-        super().__init__(
-            [self.parse_results(json_file) for json_file in json_files]
-        )
-
-    @staticmethod
-    def parse_results(jsonfile):
-        """Parse CBMC results in json output"""
-
-        results = {
-            PROGRAM: None, STATUS: [], WARNING: [],
-            RESULT: {True: [], False: []}, PROVER: None
-        }
-
-        data = parse.parse_json_file(jsonfile)
-        if data is None:
-            return results
-
-        # TODO: handle cbmc --stop-on-fail json output
-        for entry in data:
-            if JSON_PROGRAM_KEY in entry:
-                results[PROGRAM] = entry[JSON_PROGRAM_KEY]
-                continue
-
-            if JSON_MESSAGE_TYPE_KEY in entry:
-                kind = entry[JSON_MESSAGE_TYPE_KEY]
-                text = entry[JSON_MESSAGE_TEXT_KEY]
-                if kind == JSON_STATUS_MESSAGE:
-                    results[STATUS].append(text)
-                    continue
-                if kind == JSON_WARNING:
-                    results[WARNING].append(text)
-                    continue
-                raise UserWarning('Unknown CBMC json message type {}'
-                                  .format(kind))
-
-            if JSON_RESULT_KEY in entry:
-                for result in entry[JSON_RESULT_KEY]:
-                    name = result[JSON_PROPERTY_KEY]
-                    success = result[JSON_STATUS_KEY] == JSON_SUCCESS
-                    results[RESULT][success].append(name)
-                continue
-
-            if JSON_PROVER_STATUS_KEY in entry:
-                results[PROVER] = entry[JSON_PROVER_STATUS_KEY]
-                continue
-
-            raise UserWarning('Unrecognized CBMC json results data: {}'
-                              .format(entry))
-
-        return results
-
-################################################################
-# CBMC property checking results from cbmc xml output
+# Keys used in cbmc xml output
 
 XML_FAILURE_TAG = 'failure'
 XML_GOTO_TRACE_TAG = 'goto_trace'
+XML_LOCATION_TAG = 'location'
 XML_MESSAGE_TAG = 'message'
+XML_MESSAGE_TEXT_TAG = 'text'
 XML_PROGRAM_TAG = 'program'
 XML_PROVER_STATUS_TAG = 'cprover-status'
 XML_RESULT_TAG = 'result'
-XML_MESSAGE_TEXT_TAG = 'text'
 
+XML_FAILURE_PROPERTY_ATTR = 'property'
 XML_FAILURE_REASON_ATTR = 'reason'
 XML_MESSAGE_TYPE_ATTR = 'type'
 XML_RESULT_PROPERTY_ATTR = 'property'
-XML_FAILURE_PROPERTY_ATTR = 'property'
 XML_RESULT_STATUS_ATTR = 'status'
 
 XML_STATUS_MESSAGE = 'STATUS-MESSAGE'
-XML_WARNING_MESSAGE = 'WARNING'
 XML_SUCCESS_STATUS = 'SUCCESS'
+XML_WARNING_MESSAGE = 'WARNING'
 
-class ResultFromCbmcXml(Result):
-    """CBMC property checking results from CBMC xml output"""
+################################################################
+# Find PROGRAM in cbmc property checking output
 
-    def __init__(self, xml_files):
-        super().__init__(
-            [self.parse_results(xml_file) for xml_file in xml_files]
-        )
+def cbmc_text_program(log_section):
+    """Find program in cbmc text output"""
 
-    @staticmethod
-    def parse_results(xml_file):
-        """Parse CBMC results in xml output"""
+    for line in log_section:
+        if line.startswith('CBMC version'):
+            return line
+    return None
 
-        results = {
-            PROGRAM: None, STATUS: [], WARNING: [],
-            RESULT: {True: [], False: []}, PROVER: None
-        }
+def cbmc_json_program(blobs):
+    """Find program in cbmc json output"""
 
-        xml = parse.parse_xml_file(xml_file)
-        if xml is None:
-            return results
+    for blob in blobs:
+        program = blob.get(JSON_PROGRAM_KEY)
+        if program:
+            return program
+    return None
 
-        line = xml.find(XML_PROGRAM_TAG)
-        if line is not None: # Why does "if line:" not work?
-            results[PROGRAM] = line.text
+def cbmc_xml_program(blob):
+    """Find program in cbmc xml output"""
 
-        for line in xml.iter(XML_MESSAGE_TAG):
-            kind = line.get(XML_MESSAGE_TYPE_ATTR)
-            if kind == XML_STATUS_MESSAGE:
-                results[STATUS].append(line.find(XML_MESSAGE_TEXT_TAG).text)
-                continue
-            if kind == XML_WARNING_MESSAGE:
-                results[WARNING].append(line.find(XML_MESSAGE_TEXT_TAG).text)
-                continue
+    program = blob.find(XML_PROGRAM_TAG)
+    if program is not None:
+        return program.text
+    return None
 
-        # This explicit comparison with None should be redundant, but
-        # 'xml.find' is returning an object and 'if xml.find' is
-        # returning false.
-        if xml.find(XML_RESULT_TAG) is not None:
-            # cbmc produced all results as usual
-            for line in xml.iter(XML_RESULT_TAG):
-                name = line.get(XML_RESULT_PROPERTY_ATTR)
-                success = line.get(XML_RESULT_STATUS_ATTR) == XML_SUCCESS_STATUS
-                results[RESULT][success].append(name)
-        elif xml.find(XML_GOTO_TRACE_TAG) is not None:
-            # cbmc produced only a one one after being run with --stop-on-fail
-            failure = xml.find(XML_GOTO_TRACE_TAG).find(XML_FAILURE_TAG)
-            name = failure.get(XML_FAILURE_PROPERTY_ATTR)
-            results[RESULT][False].append(name)
+################################################################
+# Find STATUS messages in cbmc property checking output
 
-        line = xml.find(XML_PROVER_STATUS_TAG)
-        if line is not None: # Why does "if line:" not work?
-            results[PROVER] = line.text
+def cbmc_text_status(log_section, summary_section):
+    """Find status messages in cbmc text output"""
 
-        return results
+    status = []
+    for line in log_section:
+        if line and not line.startswith('**** WARNING:'):
+            status.append(line)
+    for line in summary_section:
+        if line and line.startswith('VERIFICATION '):
+            status.append(line)
+    return status
+
+def cbmc_json_status(blobs):
+    """Find status messages in cbmc json output"""
+
+    status = []
+    for blob in blobs:
+        kind = blob.get(JSON_MESSAGE_TYPE_KEY)
+        text = blob.get(JSON_MESSAGE_TEXT_KEY)
+        if kind == JSON_STATUS_MESSAGE:
+            status.append(text)
+    return status
+
+def cbmc_xml_status(blob):
+    """Find status messages in cbmc xml output"""
+
+    status = []
+    for msg in blob.iter(XML_MESSAGE_TAG):
+        if msg.get(XML_MESSAGE_TYPE_ATTR) == XML_STATUS_MESSAGE:
+            status.append(msg.find(XML_MESSAGE_TEXT_TAG).text)
+    return status
+
+################################################################
+# Find WARNING messages in cbmc property checking output
+
+def cbmc_text_warnings(log_section):
+    """Find warning messages in cbmc text output"""
+
+    warnings = []
+    for line in log_section:
+        if line.startswith('**** WARNING:'):
+            warnings.append(line)
+    return warnings
+
+def cbmc_json_warnings(blobs):
+    """Find warning messages in cbmc json output"""
+
+    warnings = []
+    for blob in blobs:
+        kind = blob.get(JSON_MESSAGE_TYPE_KEY)
+        text = blob.get(JSON_MESSAGE_TEXT_KEY)
+        if kind == JSON_WARNING:
+            warnings.append(text)
+    return warnings
+
+def cbmc_xml_warnings(blob):
+    """Find warning messages in cbmc xml output"""
+
+    warnings = []
+    for msg in blob.iter(XML_MESSAGE_TAG):
+        if msg.get(XML_MESSAGE_TYPE_ATTR) == XML_WARNING_MESSAGE:
+            warnings.append(msg.find(XML_MESSAGE_TEXT_TAG).text)
+    return warnings
+
+################################################################
+# Find RESULTS in cbmc property checking output
+
+EMPTY_RESULT_RESULTS = {True: [], False: []}
+
+def cbmc_text_results(results_section):
+    """Find results in cbmc text output"""
+
+    results = EMPTY_RESULT_RESULTS
+    for line in results_section:
+        # Lines given property checking results have the form
+        # [name] srcloc description: SUCCESS|FAILURE
+        match = re.match(r'\[([^ ]*)\].*: ((FAILURE)|(SUCCESS))', line)
+        if match:
+            name, status = match.groups()[:2]
+            results[status == 'SUCCESS'].append(name)
+    return results
+
+def cbmc_json_results(blobs):
+    """Find results in cbmc json output"""
+
+    results = EMPTY_RESULT_RESULTS
+    for blob in blobs:
+        for result in blob.get(JSON_RESULT_KEY) or []:
+            name, status = result[JSON_PROPERTY_KEY], result[JSON_STATUS_KEY]
+            results[status == JSON_SUCCESS].append(name)
+    return results
+
+def cbmc_xml_results(blob):
+    """Find results in cbmc xml output"""
+
+    results = EMPTY_RESULT_RESULTS
+
+    # cbmc normal output produces property checking results for all properties
+    for result in blob.iter(XML_RESULT_TAG):
+        name = result.get(XML_RESULT_PROPERTY_ATTR)
+        status = result.get(XML_RESULT_STATUS_ATTR)
+        results[status == XML_SUCCESS_STATUS].append(name)
+
+    # cbmc --stop-on-fail output produces one trace with one failure
+    if not (results[True] or results[False]):
+        trace = blob.find(XML_GOTO_TRACE_TAG)
+        if trace is not None:
+            results[False] = [trace.find(XML_FAILURE_TAG).get(XML_FAILURE_PROPERTY_ATTR)]
+
+    return results
+
+################################################################
+# Find PROVER status in cbmc property checking output
+
+def cbmc_text_prover(summary_section):
+    """Find prover status in cbmc text output"""
+
+    # Infer prover status from the lines 'VERIFICATION SUCCESSFUL' or
+    # 'VERIFICATION FAILED' in the summary section.
+
+    # In rare cases, cbmc can solve the constraint problem without
+    # invoking the constraint solver, and the string '** X of Y
+    # failed` that we use as the summary header is not printed. The
+    # string 'VERIFICATION SUCCESSFUL' that we look for in the summary
+    # section is absorbed into the log section, and the summary
+    # section is empty.
+
+    if not summary_section:
+        return SUCCESS
+
+    for line in summary_section:
+        if line == 'VERIFICATION FAILED':
+            return FAILURE
+        if line == 'VERIFICATION SUCCESSFUL':
+            return SUCCESS
+    return None
+
+def cbmc_json_prover(blobs):
+    """Find prover status in cbmc json output"""
+
+    for blob in blobs:
+        prover = blob.get(JSON_PROVER_STATUS_KEY)
+        if prover:
+            return SUCCESS if prover == JSON_PROVER_STATUS_SUCCESS else FAILURE
+    return None
+
+def cbmc_xml_prover(blob):
+    """Find prover status in cbmc xml output"""
+
+    prover = blob.find(XML_PROVER_STATUS_TAG)
+    if prover is not None:
+        return SUCCESS if prover.text == XML_SUCCESS_STATUS else FAILURE
+    return None
 
 ################################################################
 # make-result
-
-# pylint: disable=inconsistent-return-statements
 
 def fail(msg):
     """Log failure and raise exception."""

--- a/cbmc_viewer/util.py
+++ b/cbmc_viewer/util.py
@@ -3,7 +3,27 @@
 
 """Miscellaneous functions."""
 
+import logging
 import os
+
+################################################################
+
+def flatten(groups):
+    """Flatten a list of lists to a single list"""
+
+    return [item
+            for group in groups if group is not None
+            for item in group if item is not None]
+
+def choose(items):
+    """Choose an item from a list (use a deterministic choice)"""
+
+    items = sorted({item for item in items if item is not None})
+    if len(items) != 1:
+        logging.debug("No unique element in %s", items)
+    return items[0] if items else None
+
+################################################################
 
 def merge_dicts(dicts, handle_duplicate=None):
     """Merge a list of dictionaries.
@@ -31,6 +51,8 @@ def merge_dicts(dicts, handle_duplicate=None):
             result[key] = val
     return result
 
+################################################################
+
 def dump(data, filename=None, directory='.'):
     """Write data to a file or stdout."""
 
@@ -44,3 +66,5 @@ def dump(data, filename=None, directory='.'):
             print(data, file=fileobj)
     else:
         print(data)
+
+################################################################


### PR DESCRIPTION
The prior version of the result parsing (especially the text parsing)
involved large loops that were hard to understand.  This commit
refactors the code into small methods to parse for the program
version, to parse for status messages, to parse for warnings, etc.
The result makes it easier to read, but also makes it easier to see
that the text, json, and xml parsing are producing the same results.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
