### PR TITLE
Repair xml parsing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ pylint:
 		--disable=too-many-branches \
 		--module-rgx '[\w-]+' \
 	    src/cbmc_viewer/*.py
-	$(MAKE) -C tests pylint
+	$(MAKE) -C tests/bin pylint
 
 ################################################################
 # Build the distribution package

--- a/Makefile
+++ b/Makefile
@@ -39,37 +39,21 @@ unbuild:
 	$(RM) -r dist
 
 ################################################################
-# Install the package into this directory in development mode
+# Install the package into a virtual environment in development mode
 #
-# Note: This may require directory write permission (sudo): It may try
-# to update cbmc-viewer.egg-link and easy-install.pth in site-packages.
-# The Homebrew pip continues to update the system site-packages even
-# with the --user flag to pip install.
+# Note: Editable installs from pyproject.toml require at least pip 21.3
 
+VENV = /tmp/cbmc-viewer
 develop:
-	python3 -m pip install --verbose --editable . --user \
-		--install-option="--script-dir=."
+	python3 -m venv $(VENV)
+	$(VENV)/bin/python3 -m pip install --upgrade pip
+	$(VENV)/bin/python3 -m pip install -e .
 	@ echo
-	@ echo "Add cbmc-viewer to PATH with 'export PATH=$$(pwd):\$$PATH'"
+	@ echo "Add $(VENV)/bin to PATH with 'export PATH=\$$PATH:$(VENV)/bin'"
 	@ echo
 
 undevelop:
-	python3 -m pip uninstall --verbose --yes cbmc-viewer
-	$(RM) cbmc-viewer
-	$(RM) make-coverage
-	$(RM) make-loop
-	$(RM) make-property
-	$(RM) make-reachable
-	$(RM) make-result
-	$(RM) make-source
-	$(RM) make-symbol
-	$(RM) make-trace
-	$(RM) -r src/cbmc_viewer/__pycache__/
-	$(RM) -r src/cbmc_viewer.egg-info
-	@ echo
-	@ echo "This may leave cbmc-viewer in the bash command cache."
-	@ echo "Delete cbmc-viewer from the cache with 'hash -d cbmc-viewer'."
-	@ echo
+	$(RM) -r $(VENV)
 
 ################################################################
 # Install the package

--- a/src/cbmc_viewer/configt.py
+++ b/src/cbmc_viewer/configt.py
@@ -3,6 +3,9 @@
 
 """CBMC viewer configuration."""
 
+from pathlib import Path
+import logging
+
 from cbmc_viewer import parse
 
 EXPECTED_MISSING = 'expected-missing-functions'
@@ -17,9 +20,12 @@ class Config:
         if config_file is None:
             return
 
+        if not Path(config_file).exists():
+            logging.error("Config file does not exist: %s", config_file)
+            return
+
         config_data = parse.parse_json_file(config_file)
-        if config_data:
-            self.missing_functions = config_data.get(EXPECTED_MISSING, [])
+        self.missing_functions = config_data.get(EXPECTED_MISSING, [])
 
     def expected_missing_functions(self):
         """Return list of expected missing functions."""

--- a/src/cbmc_viewer/coveraget.py
+++ b/src/cbmc_viewer/coveraget.py
@@ -306,7 +306,7 @@ class CoverageFromJson(Coverage):
 def load_json(json_file):
     """Load json file produced by make-coverage"""
 
-    json_data = parse.parse_json_file(json_file, fail=True)
+    json_data = parse.parse_json_file(json_file)
     if json_data is None:
         logging.info("Found empty json coverage data.")
         return None
@@ -355,7 +355,7 @@ class CoverageFromCbmcJson(Coverage):
 def load_cbmc_json(json_file, root):
     """Load json file produced by cbmc --cover location --json-ui."""
 
-    json_data = parse.parse_json_file(json_file, fail=True)
+    json_data = parse.parse_json_file(json_file)
     if not json_data:
         logging.info("Expected coverage data in json file %s, found none",
                      json_file)
@@ -400,7 +400,7 @@ class CoverageFromCbmcXml(Coverage):
 def load_cbmc_xml(xml_file, root):
     """Load xml file produced by cbmc --cover location --xml-ui."""
 
-    xml = parse.parse_xml_file(xml_file, fail=True)
+    xml = parse.parse_xml_file(xml_file)
     if not xml or xml is None:   # Why is 'xml is None' required?
         logging.info("Expected coverage data in xml file %s, found none",
                      xml_file)

--- a/src/cbmc_viewer/loopt.py
+++ b/src/cbmc_viewer/loopt.py
@@ -159,7 +159,7 @@ class LoopFromJson(Loop):
     def __init__(self, json_files):
 
         super().__init__(
-            [parse.parse_json_file(json_file, fail=True)[JSON_TAG]['loops']
+            [parse.parse_json_file(json_file)[JSON_TAG]['loops']
              for json_file in json_files]
         )
 
@@ -177,7 +177,7 @@ class LoopFromCbmcJson(Loop):
 def load_cbmc_json(json_file, root):
     """Load a json file produced by cbmc --show-loops --json-ui."""
 
-    return parse_cbmc_json(parse.parse_json_file(json_file, fail=True), root)
+    return parse_cbmc_json(parse.parse_json_file(json_file), root)
 
 def parse_cbmc_json(json_data, root):
     """Parse the json output of cbmc --show-loops --json-ui."""
@@ -208,7 +208,7 @@ class LoopFromCbmcXml(Loop):
 def load_cbmc_xml(xml_file, root):
     """Load an xml file produced by cbmc --show-loops --xml-ui."""
 
-    return parse_cbmc_xml(parse.parse_xml_file(xml_file, fail=True), root)
+    return parse_cbmc_xml(parse.parse_xml_file(xml_file), root)
 
 def parse_cbmc_xml(xml_data, root):
     """Parse the xml output of cbmc --show-loops --xml-ui."""

--- a/src/cbmc_viewer/parse.py
+++ b/src/cbmc_viewer/parse.py
@@ -26,11 +26,6 @@ def parse_xml_string(xstr, xfile=None, fail=False):
     """Parse an xml string."""
 
     try:
-        # Messages printed by cbmc before the coverage data we care
-        # about may quote from the code, and quoted null character
-        # '\0' will appear as the string '&#0', which is unparsable by
-        # ElementTree.
-        xstr = xstr.replace('&#0;', 'null_char')
         return ElementTree.fromstring(xstr)
     except ElementTree.ParseError as err:
         if xfile:

--- a/src/cbmc_viewer/parse.py
+++ b/src/cbmc_viewer/parse.py
@@ -13,14 +13,10 @@ def parse_xml_file(xfile, fail=False):
     """Open and parse an xml file."""
 
     try:
-        with open(xfile) as data:
-            return parse_xml_string(data.read(), xfile, fail)
-    except IOError as err:
-        message = "Can't open xml file {}: {}".format(xfile, err.strerror)
-        logging.info(message)
-        if fail:
-            raise UserWarning(message) from None
-    return None
+        return ElementTree.parse(xfile)
+    except (IOError, ElementTree.ParseError) as err:
+        logging.debug("%s", err)
+        raise UserWarning(f"Can't load xml file '{xfile}'") from None
 
 def parse_xml_string(xstr, xfile=None, fail=False):
     """Parse an xml string."""

--- a/src/cbmc_viewer/parse.py
+++ b/src/cbmc_viewer/parse.py
@@ -8,7 +8,6 @@ from xml.etree import ElementTree
 
 import json
 import logging
-import re
 
 def parse_xml_file(xfile):
     """Parse an xml file."""
@@ -28,34 +27,21 @@ def parse_xml_string(xstr):
         logging.debug("%s", err)
         raise UserWarning(f"Can't parse xml string '{xstr[:40]}...'") from None
 
-def parse_json_file(jfile, goto_analyzer=False):
+def parse_json_file(jfile):
     """Parse an json file."""
 
     try:
         with open(jfile) as data:
-            if goto_analyzer:
-                return parse_json_string(data.read(), goto_analyzer)
             return json.load(data)
-    except (IOError, json.JSONDecodeError, UserWarning) as err:
+    except (IOError, json.JSONDecodeError) as err:
         logging.debug("%s", err)
         raise UserWarning(f"Can't load json file '{jfile}' in {Path.cwd()}") from None
 
-def parse_json_string(jstr, goto_analyzer=False):
+def parse_json_string(jstr):
     """Parse a json string."""
 
     try:
-        jstr = clean_up_goto_analyzer(jstr) if goto_analyzer else jstr
         return json.loads(jstr)
     except json.JSONDecodeError as err:
         logging.debug("%s", err)
         raise UserWarning(f"Can't parse json string '{jstr[:40]}...'") from None
-
-def clean_up_goto_analyzer(json_data):
-    """Clean up the json output of goto-analyzer."""
-
-    # the json produced by goto-analyzer is preceeded by a block of text
-    json_data = re.sub(r'^.*\n\[', '[', json_data, flags=re.DOTALL)
-    # the json produced by goto-analyzer sometimes omits line numbers
-    json_data = json_data.replace('"first line": ,\n', '"first line": 0,\n')
-    json_data = json_data.replace('"last line": \n', '"last line": 0\n')
-    return json_data

--- a/src/cbmc_viewer/propertyt.py
+++ b/src/cbmc_viewer/propertyt.py
@@ -148,7 +148,7 @@ class PropertyFromCbmcJson(Property):
 def load_cbmc_json(jsonfile, root):
     """Load a json file produced by cbmc --show-properties --json-ui."""
 
-    json_data = parse.parse_json_file(jsonfile, fail=True)
+    json_data = parse.parse_json_file(jsonfile)
     assert json_data is not None
 
     # Search cbmc output for {"properties": [ PROPERTY ]}
@@ -184,7 +184,7 @@ class PropertyFromCbmcXml(Property):
 def load_cbmc_xml(xmlfile, root):
     """Load a json file produced by cbmc --show-properties --xml-ui."""
 
-    xml_data = parse.parse_xml_file(xmlfile, fail=True)
+    xml_data = parse.parse_xml_file(xmlfile)
     assert xml_data is not None
 
     root = srcloct.abspath(root)

--- a/src/cbmc_viewer/reachablet.py
+++ b/src/cbmc_viewer/reachablet.py
@@ -101,7 +101,7 @@ class ReachableFromJson(Reachable):
     def __init__(self, json_files):
 
         super().__init__(
-            [parse.parse_json_file(json_file, fail=True)[JSON_TAG]["reachable"]
+            [parse.parse_json_file(json_file)[JSON_TAG]["reachable"]
              for json_file in json_files]
         )
 
@@ -120,7 +120,7 @@ class ReachableFromCbmcJson(Reachable):
 def load_cbmc_json(json_file, root):
     """Load json file produced by goto-analyzer --reachable-functions --json."""
 
-    json_data = parse.parse_json_file(json_file, fail=True, goto_analyzer=True)
+    json_data = parse.parse_json_file(json_file, goto_analyzer=True)
     return parse_cbmc_json(json_data, root)
 
 # TODO: Does file-local name mangling mess this up?
@@ -181,7 +181,7 @@ class ReachableFromGoto(Reachable):
             raise UserWarning('Failed to run {}: {}'.format(cmd, str(err))) from err
 
         json_data = parse.parse_json_string(
-            analyzer_output, fail=True, goto_analyzer=True
+            analyzer_output, goto_analyzer=True
         )
         super().__init__(
             [parse_cbmc_json(json_data, root)]


### PR DESCRIPTION
This pull request reverts to loading xml file directly from the file instead of reading the file into a string and patching the string before parsing it.  The patch appears no longer to be needed since cbmc appears no longer to insert illegal characters into its xml output.  

This pull request also reverts to raising an exception when viewer can't load an xml or json file.

This pull request also cleans up some top-level Makefile targets.

This pull request should be read commit-by-commit, as the commits themselves are small and the commit messages explain what is going on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
