### PR TITLE
Skip malformed reachable function entry 

### DIFF
--- a/src/cbmc_viewer/reachablet.py
+++ b/src/cbmc_viewer/reachablet.py
@@ -135,10 +135,16 @@ def parse_cbmc_json(json_data, root):
         if func_name.startswith('__CPROVER'):
             continue
 
+        # goto-analyzer --reachable-functions produces a malformed
+        # entry for __CPROVER_Start with an empty string for the
+        # function name.
+        if not func_name:
+            continue
+
         file_name = function.get('file')
         if file_name is None:
-            logging.error('Skipping reachable function with invalid source location: %s',
-                          function)
+            logging.warning('Skipping reachable function with invalid source location: %s',
+                            function)
             continue
 
         file_name = srcloct.abspath(file_name)


### PR DESCRIPTION
This pull request gets rid of a bogus ERROR message produced by malforned reachable function output for __CPROVER_Start


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
