### PR TITLE
Run pylint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,6 @@ default:
 
 pylint:
 	pylint	\
-		--disable=unspecified-encoding \
-		--disable=consider-using-f-string \
-		\
 		--disable=duplicate-code \
 		--disable=fixme \
 		--disable=invalid-repr-returned \

--- a/src/cbmc_viewer/coveraget.py
+++ b/src/cbmc_viewer/coveraget.py
@@ -45,7 +45,7 @@ class Status(enum.Enum):
             return "missed"
         if self == Status.BOTH:
             return "both"
-        raise UserWarning("Found unknown line coverage status: {}".format(self))
+        raise UserWarning(f"Found unknown line coverage status: {self}")
 
     def __str__(self):
         """A string representation of line coverage"""
@@ -66,8 +66,7 @@ class Status(enum.Enum):
             return Status.MISSED
         if status.lower() == "both":
             return Status.BOTH
-        raise UserWarning("Found unknown line coverage status: {}"
-                          .format(status))
+        raise UserWarning(f"Found unknown line coverage status: {status}")
 
     def combine(self, status):
         """Combine line coverage"""
@@ -226,7 +225,7 @@ def merge_coverage_data(coverage_list):
     try:
         coverage and RAW_COVERAGE_DATA(coverage)
     except voluptuous.Error as error:
-        raise UserWarning("Error merging coverage data: {}".format(error)) from error
+        raise UserWarning(f"Error merging coverage data: {error}") from error
     return coverage
 
 
@@ -315,9 +314,7 @@ def load_json(json_file):
     try:
         RAW_COVERAGE_DATA(coverage)
     except voluptuous.Error as error:
-        raise UserWarning(
-            "Error loading json coverage data: {}: {}".format(json_file, error)
-        ) from error
+        raise UserWarning(f"Error loading json coverage data: {json_file}: {error}") from error
     return coverage
 
 def repair_json(coverage):
@@ -379,9 +376,7 @@ def load_cbmc_json(json_file, root):
     try:
         RAW_COVERAGE_DATA(coverage)
     except voluptuous.Error as error:
-        raise UserWarning(
-            "Error loading cbmc json coverage data: {}: {}".format(json_file, error)
-        ) from error
+        raise UserWarning(f"Error loading cbmc json coverage data: {json_file}: {error}") from error
     return coverage
 
 ################################################################
@@ -417,9 +412,7 @@ def load_cbmc_xml(xml_file, root):
     try:
         RAW_COVERAGE_DATA(coverage)
     except voluptuous.Error as error:
-        raise UserWarning(
-            "Error loading cbmc xml coverage data: {}: {}".format(xml_file, error)
-        ) from error
+        raise UserWarning(f"Error loading cbmc xml coverage data: {xml_file}: {error}") from error
     return coverage
 
 ################################################################
@@ -568,15 +561,14 @@ def make_coverage(args):
     if viewer_coverage:
         if filet.all_json_files(viewer_coverage):
             return CoverageFromJson(viewer_coverage)
-        fail("Expected json files: {}".format(viewer_coverage))
+        fail(f"Expected json files: {viewer_coverage}")
 
     if cbmc_coverage and srcdir:
         if filet.all_json_files(cbmc_coverage):
             return CoverageFromCbmcJson(cbmc_coverage, srcdir)
         if filet.all_xml_files(cbmc_coverage):
             return CoverageFromCbmcXml(cbmc_coverage, srcdir)
-        fail("Expected json files or xml files, not both: {}"
-             .format(cbmc_coverage))
+        fail(f"Expected json files or xml files, not both: {cbmc_coverage}")
 
     logging.info("make-coverage: nothing to do: need "
                  "cbmc coverage checking results and --srcdir or "

--- a/src/cbmc_viewer/filet.py
+++ b/src/cbmc_viewer/filet.py
@@ -22,7 +22,7 @@ def filetype(filename):
         return None
 
     if not isinstance(filename, str):
-        raise UserWarning("Filename is not a string: {}".format(filename))
+        raise UserWarning(f"Filename is not a string: {filename}")
 
     # The filename extension: expected to be one of txt, jsn, json, or xml
     file_extension = os.path.splitext(filename)[1].lower().lstrip('.')
@@ -38,7 +38,7 @@ def filetype(filename):
         }[file_extension]
     except KeyError:
         raise UserWarning(
-            "Can't determine file type of file {}".format(filename)
+            f"Can't determine file type of file {filename}"
         ) from None # squash the KeyError context, raise just a UserWarning
 
 ################################################################

--- a/src/cbmc_viewer/loopt.py
+++ b/src/cbmc_viewer/loopt.py
@@ -90,7 +90,7 @@ class Loop:
         for long_name in static_names:
             long_func, index = long_name.split('.')
             short_func = long_func.split('$')[0]
-            short_name = '{}.{}'.format(short_func, index)
+            short_name = f'{short_func}.{index}'
             assert long_name != short_name
 
             if short_name in loops:
@@ -128,8 +128,7 @@ class Loop:
         if not keys:
             return None
         if len(keys) != 1:
-            raise UserWarning("Loop name {} matches {} static loop names: {}"
-                              .format(name, len(keys), keys))
+            raise UserWarning(f"Loop name {name} matches {len(keys)} static loop names: {keys}")
 
         return self.loops.get(keys[0])
 
@@ -142,7 +141,7 @@ class Loop:
         match = re.match(r'^(.*)\.unwind\.([0-9]+)$', name)
         if match is None:
             return None
-        loop = '{}.{}'.format(match.group(1), match.group(2))
+        loop = f'{match.group(1)}.{match.group(2)}'
 
         return self.lookup(loop) or self.lookup_static(loop)
 
@@ -185,8 +184,7 @@ def parse_cbmc_json(json_data, root):
     # Search cbmc output for {"loops": [ LOOP ]}
     loops = [json_map for json_map in json_data if "loops" in json_map]
     if len(loops) != 1:
-        raise UserWarning("Expected 1 set of loops in cbmc output, found {}".
-                          format(len(loops)))
+        raise UserWarning(f"Expected 1 set of loops in cbmc output, found {len(loops)}")
 
     # Each LOOP is a dict that gives a loop name and location.
     root = srcloct.abspath(root)
@@ -232,13 +230,9 @@ class LoopFromGoto(Loop):
                 [parse_cbmc_json(json.loads(runt.run(cmd, cwd=cwd)), root)]
             )
         except subprocess.CalledProcessError as err:
-            raise UserWarning(
-                'Failed to run {}: {}' .format(cmd, str(err))
-            ) from err
+            raise UserWarning(f'Failed to run {cmd}: {err}') from err
         except json.decoder.JSONDecodeError as err:
-            raise UserWarning(
-                'Failed to parse output of {}: {}'.format(cmd, str(err))
-            ) from err
+            raise UserWarning(f'Failed to parse output of {cmd}: {err}') from err
 
 ################################################################
 # make-loop
@@ -259,15 +253,14 @@ def make_loop(args):
     if viewer_loop:
         if filet.all_json_files(viewer_loop):
             return LoopFromJson(viewer_loop)
-        fail("Expected json files: {}".format(viewer_loop))
+        fail(f"Expected json files: {viewer_loop}")
 
     if cbmc_loop and srcdir:
         if filet.all_json_files(cbmc_loop):
             return LoopFromCbmcJson(cbmc_loop, srcdir)
         if filet.all_xml_files(cbmc_loop):
             return LoopFromCbmcXml(cbmc_loop, srcdir)
-        fail("Expected json files or xml files, not both: {}"
-             .format(cbmc_loop))
+        fail(f"Expected json files or xml files, not both: {cbmc_loop}")
 
     if goto and srcdir:
         return LoopFromGoto(goto, srcdir)

--- a/src/cbmc_viewer/markup_code.py
+++ b/src/cbmc_viewer/markup_code.py
@@ -41,7 +41,7 @@ class Code:
 
         try:
             # load code into a string
-            with open(os.path.join(root, path)) as source:
+            with open(os.path.join(root, path), encoding='utf-8') as source:
                 code = html.escape(untabify_code(source.read()), quote=False)
 
             # split code into blocks of code, comments, and string literals

--- a/src/cbmc_viewer/markup_link.py
+++ b/src/cbmc_viewer/markup_link.py
@@ -31,10 +31,7 @@ def path_to_file(dst, src):
 
     path = os.path.relpath(dst, os.path.dirname(src))
     if dst != os.path.normpath(os.path.join(os.path.dirname(src), path)):
-        raise UserWarning(
-            "{} != {}".format(dst,
-                              os.path.normpath(os.path.join(os.path.dirname(src), path)))
-        )
+        raise UserWarning(f"{dst} != {os.path.normpath(os.path.join(os.path.dirname(src), path))}")
     return path
 
 ################################################################
@@ -62,7 +59,7 @@ def link_text_to_file(text, to_file, from_file=None, escape_text=True):
 
     from_file = from_file or '.'
     path = path_to_file(to_file, from_file)
-    return '<a href="{}.html">{}</a>'.format(path, text)
+    return f'<a href="{path}.html">{text}</a>'
 
 def link_text_to_line(text, to_file, line, from_file=None, escape_text=True):
     """Link text to a line in a file in the source tree."""
@@ -78,7 +75,7 @@ def link_text_to_line(text, to_file, line, from_file=None, escape_text=True):
     from_file = from_file or '.'
     line = int(line)
     path = path_to_file(to_file, from_file)
-    return '<a href="{}.html#{}">{}</a>'.format(path, line, text)
+    return f'<a href="{path}.html#{line}">{text}</a>'
 
 def link_text_to_srcloc(text, srcloc, from_file=None, escape_text=True):
     """Link text to a source location in a file in the source tree."""

--- a/src/cbmc_viewer/markup_link.py
+++ b/src/cbmc_viewer/markup_link.py
@@ -29,10 +29,12 @@ def path_to_file(dst, src):
     the path from '.' to 'a/b/foo.html' is 'a/b/foo.html'.
     """
 
-    path = os.path.relpath(dst, os.path.dirname(src))
-    if dst != os.path.normpath(os.path.join(os.path.dirname(src), path)):
-        raise UserWarning(f"{dst} != {os.path.normpath(os.path.join(os.path.dirname(src), path))}")
-    return path
+    src_dir = os.path.dirname(src)
+    src_to_dst = os.path.relpath(dst, src_dir)
+    cwd_to_dst = os.path.normpath(os.path.join(src_dir, src_to_dst))
+    if dst != cwd_to_dst:
+        raise UserWarning(f"{dst} != {cwd_to_dst}")
+    return src_to_dst
 
 ################################################################
 # Method to link into the source tree.

--- a/src/cbmc_viewer/markup_trace.py
+++ b/src/cbmc_viewer/markup_trace.py
@@ -65,7 +65,7 @@ class CodeSnippet:
 
         try:
             if path not in self.source:
-                with open(os.path.join(self.root, path)) as code:
+                with open(os.path.join(self.root, path), encoding='utf-8') as code:
                     self.source[path] = code.read().splitlines()
         except FileNotFoundError as error:
             if srcloct.is_builtin(path): # <builtin-library-malloc>, etc.

--- a/src/cbmc_viewer/markup_trace.py
+++ b/src/cbmc_viewer/markup_trace.py
@@ -70,9 +70,7 @@ class CodeSnippet:
         except FileNotFoundError as error:
             if srcloct.is_builtin(path): # <builtin-library-malloc>, etc.
                 return None
-            raise UserWarning(
-                "CodeSnippet lookup: file not found: {}".format(path)
-            ) from error
+            raise UserWarning(f"CodeSnippet lookup: file not found: {path}") from error
 
         # return the whole statement which may be broken over several lines
         snippet = ' '.join(self.source[path][line:line+5])
@@ -148,6 +146,7 @@ def format_srcloc(srcloc, symbols):
     func_srcloc = symbols.lookup(func)
     # Warning: next line assumes trace root is subdirectory of code root
     from_file = os.path.join(TRACES, 'foo.html') # any name foo.html will do
+    # pylint: disable=consider-using-f-string
     return 'Function {}, File {}, Line {}'.format(
         markup_link.link_text_to_srcloc(func, func_srcloc, from_file),
         markup_link.link_text_to_file(fyle, fyle, from_file),
@@ -175,18 +174,14 @@ def format_function_call(step):
 
     name, srcloc = step['detail']['name'], step['detail']['location']
 
-    line = '-> {}'.format(
-        markup_link.link_text_to_srcloc(name, srcloc, './trace/trace.html')
-    )
+    line = f'-> {markup_link.link_text_to_srcloc(name, srcloc, "./trace/trace.html")}'
     return line
 
 def format_function_return(step):
     """Format a function return."""
 
     name, srcloc = step['detail']['name'], step['detail']['location']
-    line = '<- {}'.format(
-        markup_link.link_text_to_srcloc(name, srcloc, './trace/trace.html')
-    )
+    line = f'<- {markup_link.link_text_to_srcloc(name, srcloc, "./trace/trace.html")}'
     return line
 
 def format_variable_assignment(step):
@@ -194,28 +189,28 @@ def format_variable_assignment(step):
 
     asn = step['detail']
     lhs, rhs, binary = asn['lhs'], asn['rhs-value'], asn['rhs-binary']
-    binary = '({})'.format(binary) if binary else ''
-    return '{} = {} {}'.format(lhs, rhs, binary)
+    binary = f'({binary})' if binary else ''
+    return f'{lhs} = {rhs} {binary}'
 
 def format_parameter_assignment(step):
     """Format an assignment of an actual to formal function argument."""
 
     asn = step['detail']
     lhs, rhs, binary = asn['lhs'], asn['rhs-value'], asn['rhs-binary']
-    binary = '({})'.format(binary) if binary else ''
-    return '{} = {} {}'.format(lhs, rhs, binary)
+    binary = f'({binary})' if binary else ''
+    return f'{lhs} = {rhs} {binary}'
 
 def format_assumption(step):
     """Format a proof assumption."""
 
     pred = step['detail']['predicate']
-    return 'assumption: {}'.format(pred)
+    return f'assumption: {pred}'
 
 def format_failure(step):
     """Format a proof failure."""
 
     prop = step['detail']['property'] or "Unnamed"
     reason = step['detail']['reason'] or "Not given"
-    return 'failure: {}: {}'.format(prop, reason)
+    return f'failure: {prop}: {reason}'
 
 ################################################################

--- a/src/cbmc_viewer/parse.py
+++ b/src/cbmc_viewer/parse.py
@@ -31,7 +31,7 @@ def parse_json_file(jfile):
     """Parse an json file."""
 
     try:
-        with open(jfile) as data:
+        with open(jfile, encoding='utf-8') as data:
             return json.load(data)
     except (IOError, json.JSONDecodeError) as err:
         logging.debug("%s", err)

--- a/src/cbmc_viewer/propertyt.py
+++ b/src/cbmc_viewer/propertyt.py
@@ -154,9 +154,7 @@ def load_cbmc_json(jsonfile, root):
     # Search cbmc output for {"properties": [ PROPERTY ]}
     asserts = [json_map for json_map in json_data if "properties" in json_map]
     if len(asserts) != 1:
-        raise UserWarning("Expected 1 set of properties in cbmc output, "
-                          "found {}".
-                          format(len(asserts)))
+        raise UserWarning(f"Expected 1 set of properties in cbmc output, found {len(asserts)}")
 
     # Each PROPERTY a loop property and definition
     root = srcloct.abspath(root)
@@ -217,15 +215,14 @@ def make_property(args):
     if viewer_property:
         if filet.all_json_files(viewer_property):
             return PropertyFromJson(viewer_property)
-        fail("Expected json files: {}".format(viewer_property))
+        fail(f"Expected json files: {viewer_property}")
 
     if cbmc_property and srcdir:
         if filet.all_json_files(cbmc_property):
             return PropertyFromCbmcJson(cbmc_property, srcdir)
         if filet.all_xml_files(cbmc_property):
             return PropertyFromCbmcXml(cbmc_property, srcdir)
-        fail("Expected json files or xml files, not both: {}"
-             .format(cbmc_property))
+        fail(f"Expected json files or xml files, not both: {cbmc_property}")
 
     logging.info("make-property: nothing to do: need "
                  "cbmc property listing results (cbmc --show-properties) and --srcdir or "

--- a/src/cbmc_viewer/reachablet.py
+++ b/src/cbmc_viewer/reachablet.py
@@ -189,7 +189,7 @@ class ReachableFromGoto(Reachable):
         try:
             runt.run(cmd, cwd=cwd)
         except subprocess.CalledProcessError as err:
-            raise UserWarning('Failed to run {}: {}'.format(cmd, str(err))) from err
+            raise UserWarning(f'Failed to run {cmd}: {err}') from err
 
         json_data = parse.parse_json_file(data.name)
         os.unlink(data.name)
@@ -218,15 +218,14 @@ def make_reachable(args):
     if viewer_reachable:
         if filet.all_json_files(viewer_reachable):
             return ReachableFromJson(viewer_reachable)
-        fail("Expected json files: {}".format(viewer_reachable))
+        fail(f"Expected json files: {viewer_reachable}")
 
     if cbmc_reachable and srcdir:
         if filet.all_json_files(cbmc_reachable):
             return ReachableFromCbmcJson(cbmc_reachable, srcdir)
         if filet.all_xml_files(cbmc_reachable):
             return ReachableFromCbmcXml(cbmc_reachable, srcdir)
-        fail("Expected json files or xml files, not both: {}"
-             .format(cbmc_reachable))
+        fail(f"Expected json files or xml files, not both: {cbmc_reachable}")
 
     if goto and srcdir:
         return ReachableFromGoto(goto, srcdir)

--- a/src/cbmc_viewer/resultt.py
+++ b/src/cbmc_viewer/resultt.py
@@ -517,7 +517,7 @@ def make_result(args):
     if viewer_result:
         if filet.all_json_files(viewer_result):
             return ResultFromJson(viewer_result)
-        fail("Expected a list of json files: {}".format(viewer_result))
+        fail(f"Expected a list of json files: {viewer_result}")
 
     if cbmc_result:
         if filet.all_text_files(cbmc_result):
@@ -526,8 +526,7 @@ def make_result(args):
             return ResultFromCbmcJson(cbmc_result)
         if filet.all_xml_files(cbmc_result):
             return ResultFromCbmcXml(cbmc_result)
-        fail("Expected a list of text files, json files, or xml files: {}"
-             .format(cbmc_result))
+        fail(f"Expected a list of text files, json files, or xml files: {cbmc_result}")
 
     logging.info("make-result: nothing to do: need "
                  "cbmc property checking results or "

--- a/src/cbmc_viewer/sourcet.py
+++ b/src/cbmc_viewer/sourcet.py
@@ -165,9 +165,7 @@ class SourceFromJson(Source):
             try:
                 source = parse.parse_json_file(source_json)[JSON_TAG]
             except TypeError:
-                raise UserWarning(
-                    "Failed to load sources from {}".format(source_json)
-                ) from None
+                raise UserWarning(f"Failed to load sources from {source_json}") from None
             self.validate(source)
             return source
 
@@ -177,9 +175,7 @@ class SourceFromJson(Source):
                           for source in sources
                           for src in source['all_files']})
             if len(roots) != 1:
-                raise UserWarning(
-                    'Source lists have different roots: {}'.format(roots)
-                )
+                raise UserWarning(f'Source lists have different roots: {roots}')
             return {'root': roots[0], 'files': files}
 
         source = merge([load(source_json) for source_json in source_jsons])

--- a/src/cbmc_viewer/sourcet.py
+++ b/src/cbmc_viewer/sourcet.py
@@ -375,7 +375,7 @@ class SourceFromMake(Source):
         output = []
         for name in files:
             try:
-                with open(name) as handle:
+                with open(name, encoding='utf-8') as handle:
                     output.extend(handle.read().splitlines())
             except FileNotFoundError:
                 # The output file for the failed linking step will be in list

--- a/src/cbmc_viewer/tracet.py
+++ b/src/cbmc_viewer/tracet.py
@@ -172,7 +172,7 @@ class TraceFromJson(Trace):
 
 def load_traces(loadfile):
     """Load a trace file."""
-    with open(loadfile) as data:
+    with open(loadfile, encoding='utf-8') as data:
         return json.load(data)[JSON_TAG]
 
 ################################################################
@@ -190,7 +190,7 @@ class TraceFromCbmcText(Trace):
 def parse_text_traces(textfile, root=None, wkdir=None):
     """Parse a set of text traces."""
 
-    with open(textfile) as data:
+    with open(textfile, encoding='utf-8') as data:
         lines = '\n'.join(data.read().splitlines())
         blocks = re.split(r'\n\n+', lines)
 

--- a/src/cbmc_viewer/tracet.py
+++ b/src/cbmc_viewer/tracet.py
@@ -223,7 +223,7 @@ def parse_text_traces(textfile, root=None, wkdir=None):
             if name:
                 traces[name] = list(visible_steps(trace))
             break
-        raise UserWarning("Unknown block: {}".format(block))
+        raise UserWarning(f"Unknown block: {block}")
 
     return traces
 
@@ -237,7 +237,7 @@ def parse_text_assignment(string):
     match = re.match('([^=]+)=(.+)', string.strip())
     if match:
         return list(match.groups()[:2]) + [None]
-    raise UserWarning("Can't parse assignment: {}".format(string))
+    raise UserWarning(f"Can't parse assignment: {string}")
 
 def parse_text_state(block, root=None, wkdir=None):
     """Parse the state block in a text trace."""
@@ -397,7 +397,7 @@ def parse_xml_assignment(step, root=None):
     kind = ('variable-assignment' if akind == 'state' else
             'parameter-assignment' if akind == 'actual_parameter' else None)
     if kind is None:
-        raise UserWarning("Unknown xml assignment type: {}".format(akind))
+        raise UserWarning(f"Unknown xml assignment type: {akind}")
 
     return {
         'kind': kind,
@@ -526,13 +526,13 @@ def parse_json_assignment(step, root=None):
     kind = ('variable-assignment' if akind == 'variable' else
             'parameter-assignment' if akind == 'actual-parameter' else None)
     if kind is None:
-        raise UserWarning("Unknown json assignment type: {}".format(akind))
+        raise UserWarning(f"Unknown json assignment type: {akind}")
 
     # &v is represented as {name: pointer, data: v}
     # NULL is represented as {name: pointer, data: {((basetype *)NULL)}}
     data = step['value'].get('data')
     if step['value'].get('name') == 'pointer' and data and 'NULL' not in data:
-        data = '&{}'.format(data)
+        data = f'&{data}'
 
     return {
         'kind': kind,
@@ -638,8 +638,7 @@ def close_function_stack_frames(trace):
             pair, stack = pop_stack(stack)
             callee_name_, _, _ = pair
             if callee_name != callee_name_:
-                raise UserWarning('Function call-return mismatch: {} {}'
-                                  .format(callee_name, callee_name_))
+                raise UserWarning(f'Function call-return mismatch: {callee_name} {callee_name_}')
             continue
 
     stack.reverse()
@@ -751,7 +750,7 @@ def make_trace(args):
     if viewer_trace:
         if filet.all_json_files(viewer_trace):
             return TraceFromJson(viewer_trace)
-        fail("Expected json files: {}".format(viewer_trace))
+        fail(f"Expected json files: {viewer_trace}")
 
     if cbmc_trace and srcdir:
         if filet.all_text_files(cbmc_trace):
@@ -762,8 +761,7 @@ def make_trace(args):
             return TraceFromCbmcJson(cbmc_trace, srcdir)
         if filet.all_xml_files(cbmc_trace):
             return TraceFromCbmcXml(cbmc_trace, srcdir)
-        fail("Expected json files or xml files, not both: {}"
-             .format(cbmc_trace))
+        fail(f"Expected json files or xml files, not both: {cbmc_trace}")
 
     return Trace()
 

--- a/src/cbmc_viewer/util.py
+++ b/src/cbmc_viewer/util.py
@@ -62,7 +62,7 @@ def dump(data, filename=None, directory='.'):
     if filename:
         path = os.path.normpath(os.path.join(directory, filename))
         os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, 'w') as fileobj:
+        with open(path, 'w', encoding='utf-8') as fileobj:
             print(data, file=fileobj)
     else:
         print(data)

--- a/src/cbmc_viewer/version.py
+++ b/src/cbmc_viewer/version.py
@@ -5,7 +5,7 @@
 
 NAME = "CBMC viewer"
 NUMBER = "3.0.1"
-VERSION = "{} {}".format(NAME, NUMBER)
+VERSION = f"{NAME} {NUMBER}"
 
 def version(display=False):
     """The version of cbmc viewer."""

--- a/tests/bin/Makefile
+++ b/tests/bin/Makefile
@@ -2,10 +2,14 @@ SCRIPTS = \
   build-viewer-reports \
   compare-result \
   compare-source \
+  compare-trace \
   compare-viewer-reports
 
 pylint:
 	pylint	\
+		--disable=missing-function-docstring \
+		--disable=too-many-arguments \
+		\
 		--disable=duplicate-code \
 		--module-rgx '[\w-]+' \
 	$(SCRIPTS) *.py

--- a/tests/bin/compare-trace
+++ b/tests/bin/compare-trace
@@ -10,6 +10,8 @@
 
 import json
 
+import arguments
+
 def parse_arguments():
     """Parse command line arguments"""
 


### PR DESCRIPTION
Modify pylint disabled check: use f-strings instead of string format() and open all text files with utf-8 encoding.  Also add an omitted regression script to the list of scripts to check with pylint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
