### PR TITLE
Modify regression script difference.py to select only cbmc-viewer jobs

### DIFF
--- a/tests/bin/difference.py
+++ b/tests/bin/difference.py
@@ -170,7 +170,7 @@ def get_jobs(proof_root, litani):
     logging.info("Running litani get-jobs...")
     lines = run([litani, 'get-jobs'], cwd=proof_root)
     jobs = json.loads(' '.join(lines))
-    return [job for job in jobs if job["ci_stage"] == "report"]
+    return [job for job in jobs if job["ci_stage"] == "report" and "cbmc-viewer" in job["command"]]
 
 def set_jobs(proof_root, litani, jobs):
     logging.info("Running litani set-jobs...")


### PR DESCRIPTION
Strengthen the filter used by the regression script difference.py to
select the cbmc-viewer litani jobs.  Before this commit, the script
selected all jobs in the "report" pipeline. This commit strengthens
the filter used by difference.py to select only jobs in the "report"
pipeline with "cbmc-viewer" in the job command.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
