### PR TITLE
Kani regression

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,8 +14,12 @@ default:
 ################################################################
 # Run pylint over the package
 
-pylint:
-	pylint	\
+PYLINT=pylint
+
+pylint: pylint-viewer pylint-tests
+
+pylint-viewer:
+	$(PYLINT) \
 		--disable=duplicate-code \
 		--disable=fixme \
 		--disable=invalid-repr-returned \
@@ -24,7 +28,9 @@ pylint:
 		--disable=too-many-branches \
 		--module-rgx '[\w-]+' \
 	    src/cbmc_viewer/*.py
-	$(MAKE) -C tests/bin pylint
+
+pylint-tests:
+	$(MAKE) -C tests/bin PYLINT=$(PYLINT) pylint
 
 ################################################################
 # Build the distribution package

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 
 [metadata]
 name = cbmc-viewer
-version = 3.1
+version = 3.2
 author = Mark R. Tuttle
 author_email = mrtuttle@amazon.com
 description = CBMC viewer produces a browsable summary of CBMC findings

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     jinja2
     setuptools
     voluptuous
-python_requires = >=3.8
+python_requires = >=3.6
 
 [options.packages.find]
 where = src

--- a/src/cbmc_viewer/coveraget.py
+++ b/src/cbmc_viewer/coveraget.py
@@ -513,8 +513,8 @@ def parse_description(description):
         #   main::foo
         lines = [(fyle, func, line)
                  for chunk in basic_block.split(';')
-                 for fyle, func_lines in [chunk.split(':',1)]  # fyle:func:lines -> fyle, func:lines
-                 for func, lines in [func_lines.rsplit(':',1)] # func:lines -> func, lines
+                 for fyle, func_lines in [chunk.split(':', 1)]  # fyle:func:lines -> fyle,func:lines
+                 for func, lines in [func_lines.rsplit(':', 1)] # func:lines -> func,lines
                  for line in parse_lines(lines)]
         assert all(fyle and func and line for fyle, func, line in lines)
         return lines

--- a/src/cbmc_viewer/optionst.py
+++ b/src/cbmc_viewer/optionst.py
@@ -129,7 +129,7 @@ OPTION_GROUPS = [
           'help': """
               Load the output of "cbmc-viewer" or "cbmc-viewer property" listing the properties
               checked during CBMC property checking."""},
-        {'flag': '--viewer-reachable',
+         {'flag': '--viewer-reachable',
           'metavar': 'JSON',
           'nargs': '+',
           'help': """

--- a/src/cbmc_viewer/resultt.py
+++ b/src/cbmc_viewer/resultt.py
@@ -194,7 +194,7 @@ def cbmc_text_sections(text_file):
     with open(text_file, encoding='utf-8') as blob:
         # The blob is an iterator that iterates through the lines of
         # the file and throws StopIteration at the end of the file.
-        next_line = lambda : next(blob).rstrip()
+        next_line = lambda: next(blob).rstrip()
         try:
             line = next_line()
 

--- a/src/cbmc_viewer/version.py
+++ b/src/cbmc_viewer/version.py
@@ -4,7 +4,7 @@
 """Version number."""
 
 NAME = "CBMC viewer"
-NUMBER = "3.1"
+NUMBER = "3.2"
 VERSION = f"{NAME} {NUMBER}"
 
 def version(display=False):

--- a/tests/bin/Makefile
+++ b/tests/bin/Makefile
@@ -5,8 +5,10 @@ SCRIPTS = \
   compare-trace \
   compare-viewer-reports
 
+PYLINT=pylint
+
 pylint:
-	pylint	\
+	$(PYLINT) \
 		--disable=missing-function-docstring \
 		--disable=too-many-arguments \
 		\

--- a/tests/kani/.gitignore
+++ b/tests/kani/.gitignore
@@ -1,0 +1,2 @@
+kani
+build.ninja

--- a/tests/kani/Makefile
+++ b/tests/kani/Makefile
@@ -1,0 +1,47 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+SHELL=/bin/bash
+
+# Assume cbmc and cbmc-viewer are installed in PATH
+#   skip ./kani/scripts/setup/ubuntu/install_cbmc.sh
+#   skip ./kani/scripts/setup/install_viewer.sh 2.11
+
+KANI?=kani
+
+# ARCH is ubuntu or macos-10.15
+ARCH?=ubuntu
+
+clone:
+	git clone https://github.com/model-checking/kani.git $(KANI)
+	cd $(KANI) && git submodule update --init
+
+# MacOS warning: If brew fails trying to install ctags over
+# universal-ctags, then replace ctags with universal-ctags
+# ./kani/scripts/setup/macos-10.15/install_deps.sh
+
+build:
+	PATH=$$HOME/.cargo/bin:$$PATH $(MAKE) build_
+
+build_:
+	./$(KANI)/scripts/setup/$(ARCH)/install_deps.sh
+	./$(KANI)/scripts/setup/install_rustup.sh
+	cd $(KANI) && cargo build --workspace
+
+test:
+	PATH=$$HOME/.cargo/bin:$$(pwd)/$(KANI)/scripts:$$PATH $(MAKE) version test_
+
+test_:
+	./write_build_ninja.py $(KANI)/tests/kani
+	ninja
+
+version:
+	@ echo cbmc --version: $$(cbmc --version) >&2
+	@ echo cbmc-viewer --version: $$(cbmc-viewer --version) >&2
+	@ echo kani --version: $$(kani --version) >&2
+
+clean:
+	$(RM) -r *~ build.ninja .ninja_log __pycache__
+
+veryclean: clean
+	$(RM) -r $(KANI)

--- a/tests/kani/write_build_ninja.py
+++ b/tests/kani/write_build_ninja.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+import re
+import subprocess
+import sys
+
+import ninja_syntax
+
+RULE_NAME = 'kani'
+BUILD_COUNT = 0
+
+def rust_sources(root):
+    sources = subprocess.run(
+        ['find', root, '-name', '*.rs'],
+        encoding='utf-8',
+        universal_newlines=True,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    ).stdout.splitlines()
+    # source files with names including 'ignore' and 'fixme' are broken
+    # source file 'ForeignItems/main.rs' is also broken
+    tags = ['ignore', 'fixme', 'tests/kani/ForeignItems/main.rs']
+    return [src for src in sources if all(tag not in src for tag in tags)]
+
+def kani_pragma(pragma, rust_code):
+    # Examples of kani pragmas:
+    # // kani-verify-fail
+    # // kani-check-fail
+    # // kani-flags: --default-unwind 8
+    try:
+        regexp = fr'//[ \t]*{pragma}([^\n]*)'
+        return re.search(regexp, rust_code).group(1).strip()
+    except AttributeError: # 'NoneType' object has no attribute 'group'
+        return None
+
+def kani_verify_fail(rust_code):
+    return kani_pragma('kani-verify-fail', rust_code) is not None
+
+def kani_check_fail(rust_code):
+    return kani_pragma('kani-check-fail', rust_code) is not None
+
+def kani_flags(rust_code):
+    return kani_pragma('kani-flags:', rust_code) or ""
+
+def ninja_build_statements(source):
+    source = Path(source)
+    with open(source, encoding='utf-8') as src:
+        rust_code = src.read()
+    if kani_verify_fail(rust_code) or kani_check_fail(rust_code):
+        return []
+
+    # Warning: concurrent invocations of kani in a single directory
+    # should generate race conditions that have so far been
+    # unobserved.  The count variable here is just a hack just to get
+    # ninja to run.
+    # TODO: Define one pool of depth 1 for each directory, and assign
+    # all kani runs on all proofs in that directory to that pool.
+    global BUILD_COUNT
+    BUILD_COUNT += 1
+    return [{'outputs': [f'{source}-{BUILD_COUNT}'],
+             'rule': RULE_NAME,
+             'inputs':  str(source),
+             'variables': {'dir': str(source.parent),
+                           'src': str(source.name),
+                           'flags': kani_flags(rust_code)}}]
+
+def build_ninja_file(sources, build='build.ninja'):
+    with open(build, 'w', encoding='utf-8') as output:
+        writer = ninja_syntax.Writer(output)
+        writer.rule(RULE_NAME, 'cd "${dir}" && kani ${flags} --visualize ${src}')
+        for source in sources:
+            for build in ninja_build_statements(source):
+                writer.build(**build)
+
+def main():
+    try:
+        root = sys.argv[1]
+    except IndexError:
+        root = 'kani/tests/kani'
+    sources = rust_sources(root)
+    build_ninja_file(sources)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This pull request adds regression tests that run kani --visualize to test viewer on kani tests.

This pull request also does some minor cleanup, resets required python version back to 3.6 and advances version number to 3.2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
