### PR TITLE
Extract ctags support as a stand-alone module

### DIFF
--- a/.github/workflows/ctags.yaml
+++ b/.github/workflows/ctags.yaml
@@ -1,0 +1,92 @@
+name: Test generating symbols from ctags
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  legacy:
+    name: Legacy ctags test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install viewer
+        run: |
+          make install
+      - name: Install brew packages
+        run: |
+          brew uninstall ctags || true
+          brew uninstall universal-ctags || true
+          brew install cbmc cbmc-starter-kit litani
+      - name: Build goto
+        run: |
+          cd tests/unit-tests/ctags
+          make clone
+          pushd coreHTTP/test/cbmc
+          cbmc-starter-kit-update --remove-litani --remove-starter
+          popd
+          make build
+      - name: Test legacy ctags
+        run: |
+          cd tests/unit-tests/ctags
+          ctags || true
+          make legacy
+
+  exuberant:
+    name: Exuberant ctags test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install viewer
+        run: |
+          make install
+      - name: Install brew packages
+        run: |
+          brew uninstall ctags || true
+          brew uninstall universal-ctags || true
+          brew install cbmc cbmc-starter-kit litani ctags
+      - name: Build goto
+        run: |
+          cd tests/unit-tests/ctags
+          make clone
+          pushd coreHTTP/test/cbmc
+          cbmc-starter-kit-update --remove-litani --remove-starter
+          popd
+          make build
+      - name: Run exuberant ctags test
+        run: |
+          cd tests/unit-tests/ctags
+          ctags --version
+          make exuberant
+
+  universal:
+    name: Universal ctags test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install viewer
+        run: |
+          make install
+      - name: Install brew packages
+        run: |
+          brew uninstall ctags || true
+          brew uninstall universal-ctags || true
+          brew install cbmc cbmc-starter-kit litani universal-ctags
+      - name: Build goto
+        run: |
+          cd tests/unit-tests/ctags
+          make clone
+          pushd coreHTTP/test/cbmc
+          cbmc-starter-kit-update --remove-litani --remove-starter
+          popd
+          make build
+      - name: Run universal ctags test
+        run: |
+          cd tests/unit-tests/ctags
+          ctags --version
+          make universal

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 
 [metadata]
 name = cbmc-viewer
-version = 3.2
+version = 3.3
 author = Mark R. Tuttle
 author_email = mrtuttle@amazon.com
 description = CBMC viewer produces a browsable summary of CBMC findings

--- a/src/cbmc_viewer/ctagst.py
+++ b/src/cbmc_viewer/ctagst.py
@@ -142,7 +142,6 @@ def legacy_ctags(root, files):
     except UserWarning:
         logging.info("Legacy ctags failed")
         strings = []
-    print(strings)
     return [tag for string in strings for tag in legacy_tag(root, string)]
 
 def legacy_tag(root, string):

--- a/src/cbmc_viewer/version.py
+++ b/src/cbmc_viewer/version.py
@@ -4,7 +4,7 @@
 """Version number."""
 
 NAME = "CBMC viewer"
-NUMBER = "3.2"
+NUMBER = "3.3"
 VERSION = f"{NAME} {NUMBER}"
 
 def version(display=False):

--- a/tests/unit-tests/ctags/.gitignore
+++ b/tests/unit-tests/ctags/.gitignore
@@ -1,0 +1,2 @@
+coreHTTP
+symbol.json

--- a/tests/unit-tests/ctags/Makefile
+++ b/tests/unit-tests/ctags/Makefile
@@ -1,0 +1,47 @@
+# The FreeRTOS coreHTTP respository
+REPO_DIR = coreHTTP
+REPO_URL = https://github.com/FreeRTOS/coreHTTP.git
+
+# Paths in the repository
+PROOF_DIR = test/cbmc/proofs
+
+# Proofs in the repository
+PROOF = HTTPClient_AddRangeHeader
+
+UNIVERSAL=$$(ctags --version | grep Universal)
+EXUBERANT=$$(ctags --version | grep Exuberant)
+
+default: clone build compare
+
+# Clone the repository
+clone:
+	$(RM) -r $(REPO_DIR)
+	git clone $(REPO_URL) $(REPO_DIR)
+	cd $(REPO_DIR); git submodule update --init --checkout --recursive
+
+# Run a proofs
+#   EXTERNAL_SAT_SOLVER= to ensure cbmc uses minisat and not kissat
+build:
+	cd $(REPO_DIR)/$(PROOF_DIR)/$(PROOF); \
+	    EXTERNAL_SAT_SOLVER= \
+	    make goto
+
+symbol:
+	cbmc-viewer symbol \
+		--goto $(REPO_DIR)/$(PROOF_DIR)/$(PROOF)/gotos/$(PROOF)_harness.goto \
+		--srcdir $(REPO_DIR) > symbol.json
+
+legacy: symbol
+	diff symbol.json symbol-legacy.json
+
+exuberant: symbol
+	diff symbol.json symbol-exuberant.json
+
+universal: symbol
+	diff symbol.json symbol-universal.json
+
+clean:
+	$(RM) *~ symbol.json
+
+veryclean: clean
+	$(RM) -r $(REPO_DIR)

--- a/tests/unit-tests/ctags/symbol-exuberant.json
+++ b/tests/unit-tests/ctags/symbol-exuberant.json
@@ -1,0 +1,3131 @@
+{
+  "viewer-symbol": {
+    "symbols": {
+      "CARRIAGE_RETURN_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 74
+      },
+      "COLON_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 76
+      },
+      "CORE_HTTP_CLIENT_H_": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 29
+      },
+      "CORE_HTTP_CLIENT_PRIVATE_H_": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 29
+      },
+      "DASH_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 70
+      },
+      "DASH_CHARACTER_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 71
+      },
+      "F_CHUNKED": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 91
+      },
+      "F_CONNECTION_CLOSE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 89
+      },
+      "F_CONNECTION_KEEP_ALIVE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 88
+      },
+      "F_CONNECTION_UPGRADE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 90
+      },
+      "F_CONTENT_LENGTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 93
+      },
+      "F_SKIPBODY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 94
+      },
+      "F_TRAILING": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 95
+      },
+      "F_TRANSFER_ENCODING": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 96
+      },
+      "F_UPGRADE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 92
+      },
+      "HPE_CB_CHUNK_COMPLETE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 79
+      },
+      "HPE_CB_CHUNK_HEADER": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 78
+      },
+      "HPE_CB_HEADERS_COMPLETE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 76
+      },
+      "HPE_CB_MESSAGE_BEGIN": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 75
+      },
+      "HPE_CB_MESSAGE_COMPLETE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 77
+      },
+      "HPE_CLOSED_CONNECTION": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 64
+      },
+      "HPE_INTERNAL": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 60
+      },
+      "HPE_INVALID_CHUNK_SIZE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 71
+      },
+      "HPE_INVALID_CONSTANT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 67
+      },
+      "HPE_INVALID_CONTENT_LENGTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 70
+      },
+      "HPE_INVALID_EOF_STATE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 73
+      },
+      "HPE_INVALID_HEADER_TOKEN": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 69
+      },
+      "HPE_INVALID_METHOD": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 65
+      },
+      "HPE_INVALID_STATUS": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 72
+      },
+      "HPE_INVALID_TRANSFER_ENCODING": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 74
+      },
+      "HPE_INVALID_URL": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 66
+      },
+      "HPE_INVALID_VERSION": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 68
+      },
+      "HPE_LF_EXPECTED": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 62
+      },
+      "HPE_OK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 59
+      },
+      "HPE_PAUSED": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 80
+      },
+      "HPE_PAUSED_H2_UPGRADE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 82
+      },
+      "HPE_PAUSED_UPGRADE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 81
+      },
+      "HPE_STRICT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 61
+      },
+      "HPE_UNEXPECTED_CONTENT_LENGTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 63
+      },
+      "HPE_USER": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 83
+      },
+      "HTTPClient_AddHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1635
+      },
+      "HTTPClient_AddHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1641
+      },
+      "HTTPClient_AddHeader::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1637
+      },
+      "HTTPClient_AddHeader::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1636
+      },
+      "HTTPClient_AddHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1635
+      },
+      "HTTPClient_AddHeader::pValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1638
+      },
+      "HTTPClient_AddHeader::valueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1639
+      },
+      "HTTPClient_AddRangeHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1695
+      },
+      "HTTPClient_AddRangeHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1699
+      },
+      "HTTPClient_AddRangeHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1695
+      },
+      "HTTPClient_AddRangeHeader::rangeEnd": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1697
+      },
+      "HTTPClient_AddRangeHeader::rangeStartOrlastNbytes": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1696
+      },
+      "HTTPClient_AddRangeHeader_harness": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 32
+      },
+      "HTTPClient_AddRangeHeader_harness::$tmp::return_value_isValidHttpRequestHeaders": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 40
+      },
+      "HTTPClient_AddRangeHeader_harness::1::pRequestHeaders": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 34
+      },
+      "HTTPClient_AddRangeHeader_harness::1::rangeEnd": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 36
+      },
+      "HTTPClient_AddRangeHeader_harness::1::rangeStartOrlastNbytes": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 35
+      },
+      "HTTPClient_GetCurrentTimeFunc_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 418
+      },
+      "HTTPClient_InitializeRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1538
+      },
+      "HTTPClient_InitializeRequestHeaders::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1541
+      },
+      "HTTPClient_InitializeRequestHeaders::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1538
+      },
+      "HTTPClient_InitializeRequestHeaders::pRequestInfo": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1539
+      },
+      "HTTPClient_ReadHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2479
+      },
+      "HTTPClient_ReadHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2485
+      },
+      "HTTPClient_ReadHeader::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2481
+      },
+      "HTTPClient_ReadHeader::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2480
+      },
+      "HTTPClient_ReadHeader::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2479
+      },
+      "HTTPClient_ReadHeader::pValueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2483
+      },
+      "HTTPClient_ReadHeader::pValueLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2482
+      },
+      "HTTPClient_ResponseHeaderParsingCallback": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 387
+      },
+      "HTTPClient_ResponseHeaderParsingCallback_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 409
+      },
+      "HTTPClient_Send": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2135
+      },
+      "HTTPClient_Send::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2142
+      },
+      "HTTPClient_Send::pRequestBodyBuf": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2137
+      },
+      "HTTPClient_Send::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2136
+      },
+      "HTTPClient_Send::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2139
+      },
+      "HTTPClient_Send::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2135
+      },
+      "HTTPClient_Send::reqBodyBufLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2138
+      },
+      "HTTPClient_Send::sendFlags": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2140
+      },
+      "HTTPClient_strerror": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2544
+      },
+      "HTTPClient_strerror::1::str": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2546
+      },
+      "HTTPClient_strerror::status": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2544
+      },
+      "HTTPHeaderNotFound": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 296
+      },
+      "HTTPInsufficientMemory": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 224
+      },
+      "HTTPInvalidParameter": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 185
+      },
+      "HTTPInvalidResponse": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 305
+      },
+      "HTTPNetworkError": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 193
+      },
+      "HTTPNoResponse": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 212
+      },
+      "HTTPParserInternalError": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 288
+      },
+      "HTTPParsingContext": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 286
+      },
+      "HTTPParsingContext_t": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 299
+      },
+      "HTTPParsingState_t": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 213
+      },
+      "HTTPPartialResponse": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 201
+      },
+      "HTTPRequestHeaders": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 319
+      },
+      "HTTPRequestHeaders_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 344
+      },
+      "HTTPRequestInfo": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 350
+      },
+      "HTTPRequestInfo_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 378
+      },
+      "HTTPResponse": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 424
+      },
+      "HTTPResponse_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 525
+      },
+      "HTTPSecurityAlertExtraneousResponseData": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 233
+      },
+      "HTTPSecurityAlertInvalidCharacter": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 269
+      },
+      "HTTPSecurityAlertInvalidChunkHeader": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 241
+      },
+      "HTTPSecurityAlertInvalidContentLength": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 279
+      },
+      "HTTPSecurityAlertInvalidProtocolVersion": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 250
+      },
+      "HTTPSecurityAlertInvalidStatusCode": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 259
+      },
+      "HTTPStatus": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 161
+      },
+      "HTTPStatus_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 306
+      },
+      "HTTPSuccess": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 173
+      },
+      "HTTP_ACL": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 141
+      },
+      "HTTP_ALL_METHOD_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 253
+      },
+      "HTTP_ANNOUNCE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 158
+      },
+      "HTTP_BIND": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 138
+      },
+      "HTTP_BOTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 108
+      },
+      "HTTP_CBMC_STATE_H_": {
+        "file": "test/cbmc/include/http_cbmc_state.h",
+        "function": null,
+        "line": 29
+      },
+      "HTTP_CHECKOUT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 144
+      },
+      "HTTP_CONNECT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 127
+      },
+      "HTTP_CONNECTION_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 99
+      },
+      "HTTP_CONNECTION_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 100
+      },
+      "HTTP_CONNECTION_KEEP_ALIVE_VALUE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 110
+      },
+      "HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 116
+      },
+      "HTTP_CONTENT_LENGTH_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 101
+      },
+      "HTTP_CONTENT_LENGTH_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 102
+      },
+      "HTTP_COPY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 130
+      },
+      "HTTP_DELETE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 122
+      },
+      "HTTP_DESCRIBE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 157
+      },
+      "HTTP_EMPTY_PATH": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 58
+      },
+      "HTTP_EMPTY_PATH_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 59
+      },
+      "HTTP_ERRNO_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 171
+      },
+      "HTTP_FINISH_SAFE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 115
+      },
+      "HTTP_FINISH_SAFE_WITH_CB": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 116
+      },
+      "HTTP_FINISH_UNSAFE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 117
+      },
+      "HTTP_FLUSH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 167
+      },
+      "HTTP_GET": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 123
+      },
+      "HTTP_GET_PARAMETER": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 163
+      },
+      "HTTP_HEAD": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 124
+      },
+      "HTTP_HEADER_END_INDICATOR": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 64
+      },
+      "HTTP_HEADER_END_INDICATOR_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 65
+      },
+      "HTTP_HEADER_FIELD_SEPARATOR": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 66
+      },
+      "HTTP_HEADER_FIELD_SEPARATOR_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 67
+      },
+      "HTTP_HEADER_LINE_SEPARATOR": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 62
+      },
+      "HTTP_HEADER_LINE_SEPARATOR_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 63
+      },
+      "HTTP_HEADER_STRNCPY_IS_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 88
+      },
+      "HTTP_HEADER_STRNCPY_IS_VALUE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 82
+      },
+      "HTTP_HOST_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 94
+      },
+      "HTTP_HOST_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 95
+      },
+      "HTTP_LINK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 153
+      },
+      "HTTP_LOCK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 131
+      },
+      "HTTP_MAX_CONTENT_LENGTH_HEADER_LENGTH": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 71
+      },
+      "HTTP_MAX_RANGE_REQUEST_VALUE_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 157
+      },
+      "HTTP_MERGE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 145
+      },
+      "HTTP_METHOD_GET": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 60
+      },
+      "HTTP_METHOD_HEAD": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 63
+      },
+      "HTTP_METHOD_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 199
+      },
+      "HTTP_METHOD_POST": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 62
+      },
+      "HTTP_METHOD_PUT": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 61
+      },
+      "HTTP_MINIMUM_REQUEST_LINE_LENGTH": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 202
+      },
+      "HTTP_MKACTIVITY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 143
+      },
+      "HTTP_MKCALENDAR": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 152
+      },
+      "HTTP_MKCOL": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 132
+      },
+      "HTTP_MOVE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 133
+      },
+      "HTTP_MSEARCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 146
+      },
+      "HTTP_NOTIFY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 147
+      },
+      "HTTP_OPTIONS": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 128
+      },
+      "HTTP_PARSING_COMPLETE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 212
+      },
+      "HTTP_PARSING_INCOMPLETE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 211
+      },
+      "HTTP_PARSING_NONE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 210
+      },
+      "HTTP_PATCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 150
+      },
+      "HTTP_PAUSE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 161
+      },
+      "HTTP_PLAY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 160
+      },
+      "HTTP_POST": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 125
+      },
+      "HTTP_PRI": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 156
+      },
+      "HTTP_PROPFIND": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 134
+      },
+      "HTTP_PROPPATCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 135
+      },
+      "HTTP_PROTOCOL_VERSION": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 52
+      },
+      "HTTP_PROTOCOL_VERSION_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 53
+      },
+      "HTTP_PURGE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 151
+      },
+      "HTTP_PUT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 126
+      },
+      "HTTP_RANGE_REQUEST_END_OF_FILE": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 155
+      },
+      "HTTP_RANGE_REQUEST_HEADER_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 124
+      },
+      "HTTP_RANGE_REQUEST_HEADER_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 130
+      },
+      "HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 136
+      },
+      "HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 142
+      },
+      "HTTP_REBIND": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 139
+      },
+      "HTTP_RECORD": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 166
+      },
+      "HTTP_REDIRECT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 165
+      },
+      "HTTP_REPORT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 142
+      },
+      "HTTP_REQUEST": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 109
+      },
+      "HTTP_REQUEST_KEEP_ALIVE_FLAG": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 112
+      },
+      "HTTP_RESPONSE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 110
+      },
+      "HTTP_RESPONSE_CONNECTION_CLOSE_FLAG": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 133
+      },
+      "HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 141
+      },
+      "HTTP_SEARCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 136
+      },
+      "HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 90
+      },
+      "HTTP_SETUP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 159
+      },
+      "HTTP_SET_PARAMETER": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 164
+      },
+      "HTTP_SOURCE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 155
+      },
+      "HTTP_SUBSCRIBE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 148
+      },
+      "HTTP_TEARDOWN": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 162
+      },
+      "HTTP_TRACE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 129
+      },
+      "HTTP_UNBIND": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 140
+      },
+      "HTTP_UNLINK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 154
+      },
+      "HTTP_UNLOCK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 137
+      },
+      "HTTP_UNSUBSCRIBE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 149
+      },
+      "HTTP_USER_AGENT_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 92
+      },
+      "HTTP_USER_AGENT_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 93
+      },
+      "HTTP_USER_AGENT_VALUE_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 96
+      },
+      "INCLUDE_LLHTTP_API_H_": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 308
+      },
+      "INCLUDE_LLHTTP_H_": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 2
+      },
+      "INCLUDE_LLHTTP_ITSELF_H_": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 13
+      },
+      "LENIENT_CHUNKED_LENGTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 102
+      },
+      "LENIENT_HEADERS": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 101
+      },
+      "LENIENT_KEEP_ALIVE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 103
+      },
+      "LINEFEED_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 75
+      },
+      "LLHTTP_CONTINUE_PARSING": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 165
+      },
+      "LLHTTP_EXPORT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 315
+      },
+      "LLHTTP_STOP_PARSING": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 171
+      },
+      "LLHTTP_STOP_PARSING_NO_BODY": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 177
+      },
+      "LLHTTP_STOP_PARSING_NO_HEADER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 186
+      },
+      "LLHTTP_STRICT_MODE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 9
+      },
+      "LLHTTP_VERSION_MAJOR": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 4
+      },
+      "LLHTTP_VERSION_MINOR": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 5
+      },
+      "LLHTTP_VERSION_PATCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 6
+      },
+      "LLLLHTTP_C_HEADERS_": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 53
+      },
+      "MAX_INT32_NO_OF_DECIMAL_DIGITS": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 149
+      },
+      "MAX_TRIES": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 37
+      },
+      "NetworkContext": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 188
+      },
+      "NetworkContext_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 189
+      },
+      "RTSP_METHOD_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 236
+      },
+      "SPACE_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 68
+      },
+      "SPACE_CHARACTER_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 69
+      },
+      "TRANSPORT_INTERFACE_H_": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 29
+      },
+      "TRANSPORT_INTERFACE_STUBS_H_": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 30
+      },
+      "TransportInterface": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 251
+      },
+      "TransportInterfaceReceiveStub": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 62
+      },
+      "TransportInterfaceSendStub": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 49
+      },
+      "TransportInterface_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 256
+      },
+      "TransportRecv_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 219
+      },
+      "TransportSend_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 241
+      },
+      "__builtin___strncpy_chk": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 39
+      },
+      "__builtin___strncpy_chk::dest": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 39
+      },
+      "__builtin___strncpy_chk::n": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 41
+      },
+      "__builtin___strncpy_chk::os": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 42
+      },
+      "__builtin___strncpy_chk::src": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 40
+      },
+      "__has_builtin": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 35
+      },
+      "_current": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 29
+      },
+      "_index": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 22
+      },
+      "_span_cb0": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 24
+      },
+      "_span_pos0": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 23
+      },
+      "addContentLengthHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1840
+      },
+      "addContentLengthHeader::1::contentLengthValueNumBytes": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1845
+      },
+      "addContentLengthHeader::1::pContentLengthValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1844
+      },
+      "addContentLengthHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1843
+      },
+      "addContentLengthHeader::contentLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1841
+      },
+      "addContentLengthHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1840
+      },
+      "addHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1306
+      },
+      "addHeader::$tmp::return_value_httpHeaderStrncpy": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1350
+      },
+      "addHeader::$tmp::return_value_httpHeaderStrncpy$0": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1367
+      },
+      "addHeader::$tmp::return_value_strncmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1331
+      },
+      "addHeader::1::backtrackHeaderLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1315
+      },
+      "addHeader::1::pBufferCur": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1313
+      },
+      "addHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1312
+      },
+      "addHeader::1::toAddLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1314
+      },
+      "addHeader::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1308
+      },
+      "addHeader::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1307
+      },
+      "addHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1306
+      },
+      "addHeader::pValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1309
+      },
+      "addHeader::valueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1310
+      },
+      "addRangeHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1401
+      },
+      "addRangeHeader::$tmp::return_value_convertInt32ToAscii": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1425
+      },
+      "addRangeHeader::$tmp::return_value_convertInt32ToAscii$0": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1439
+      },
+      "addRangeHeader::1::rangeValueBuffer": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1406
+      },
+      "addRangeHeader::1::rangeValueLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1407
+      },
+      "addRangeHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1405
+      },
+      "addRangeHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1401
+      },
+      "addRangeHeader::rangeEnd": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1403
+      },
+      "addRangeHeader::rangeStartOrlastNbytes": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1402
+      },
+      "allocateFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 270
+      },
+      "allocateFindHeaderContext::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 274
+      },
+      "allocateFindHeaderContext::pFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 270
+      },
+      "allocateHttpReadHeaderParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 254
+      },
+      "allocateHttpReadHeaderParser::$tmp::return_value_allocateFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 264
+      },
+      "allocateHttpReadHeaderParser::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 260
+      },
+      "allocateHttpReadHeaderParser::1::pFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 256
+      },
+      "allocateHttpReadHeaderParser::pHttpParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 254
+      },
+      "allocateHttpRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 38
+      },
+      "allocateHttpRequestHeaders::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 42
+      },
+      "allocateHttpRequestHeaders::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 48
+      },
+      "allocateHttpRequestHeaders::pRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 38
+      },
+      "allocateHttpRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 67
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 71
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 77
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail$1": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 80
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail$2": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 83
+      },
+      "allocateHttpRequestInfo::pRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 67
+      },
+      "allocateHttpResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 103
+      },
+      "allocateHttpResponse::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 109
+      },
+      "allocateHttpResponse::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 115
+      },
+      "allocateHttpResponse::$tmp::return_value_nondet_bool": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 123
+      },
+      "allocateHttpResponse::$tmp::return_value_nondet_bool$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 145
+      },
+      "allocateHttpResponse::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 123
+      },
+      "allocateHttpResponse::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 145
+      },
+      "allocateHttpResponse::1::bodyOffset": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 105
+      },
+      "allocateHttpResponse::1::headerOffset": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 105
+      },
+      "allocateHttpResponse::pResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 103
+      },
+      "allocateHttpSendParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 203
+      },
+      "allocateHttpSendParser::$tmp::return_value_isValidHttpSendParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 214
+      },
+      "allocateHttpSendParser::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 209
+      },
+      "allocateHttpSendParser::1::pHttpParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 205
+      },
+      "allocateHttpSendParser::pHttpParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 203
+      },
+      "allocateHttpSendParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 220
+      },
+      "allocateHttpSendParsingContext::$tmp::return_value_isValidHttpResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 231
+      },
+      "allocateHttpSendParsingContext::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 227
+      },
+      "allocateHttpSendParsingContext::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 231
+      },
+      "allocateHttpSendParsingContext::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 234
+      },
+      "allocateHttpSendParsingContext::1::bufferOffset": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 223
+      },
+      "allocateHttpSendParsingContext::1::pResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 222
+      },
+      "allocateHttpSendParsingContext::pHttpParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 220
+      },
+      "allocateTransportInterface": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 175
+      },
+      "allocateTransportInterface::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 179
+      },
+      "allocateTransportInterface::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 184
+      },
+      "allocateTransportInterface::pTransport": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 175
+      },
+      "bodyLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 493
+      },
+      "bufferLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 336
+      },
+      "caseInsensitiveStringCmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 572
+      },
+      "caseInsensitiveStringCmp::$tmp::return_value_toupper": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 580
+      },
+      "caseInsensitiveStringCmp::$tmp::return_value_toupper$0": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 580
+      },
+      "caseInsensitiveStringCmp::1::i": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 576
+      },
+      "caseInsensitiveStringCmp::n": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 574
+      },
+      "caseInsensitiveStringCmp::str1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 572
+      },
+      "caseInsensitiveStringCmp::str2": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 573
+      },
+      "contentLength": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 509
+      },
+      "content_length": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 30
+      },
+      "convertInt32ToAscii": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1204
+      },
+      "convertInt32ToAscii::1::absoluteValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1214
+      },
+      "convertInt32ToAscii::1::index": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1216
+      },
+      "convertInt32ToAscii::1::isNegative": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1217
+      },
+      "convertInt32ToAscii::1::numOfDigits": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1215
+      },
+      "convertInt32ToAscii::1::temp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1218
+      },
+      "convertInt32ToAscii::bufferLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1206
+      },
+      "convertInt32ToAscii::pBuffer": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1205
+      },
+      "convertInt32ToAscii::value": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1204
+      },
+      "data": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 28
+      },
+      "error": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 25
+      },
+      "error_pos": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 27
+      },
+      "fieldFound": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 226
+      },
+      "fieldLen": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 223
+      },
+      "filler": {
+        "file": "test/cbmc/include/http_cbmc_state.h",
+        "function": null,
+        "line": 41
+      },
+      "findHeaderContext": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 220
+      },
+      "findHeaderContext_t": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 228
+      },
+      "findHeaderFieldParserCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2238
+      },
+      "findHeaderFieldParserCallback::$tmp::return_value_caseInsensitiveStringCmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2261
+      },
+      "findHeaderFieldParserCallback::$tmp::tmp_if_expr": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2260
+      },
+      "findHeaderFieldParserCallback::1::pContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2242
+      },
+      "findHeaderFieldParserCallback::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2240
+      },
+      "findHeaderFieldParserCallback::pFieldLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2239
+      },
+      "findHeaderFieldParserCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2238
+      },
+      "findHeaderInResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2371
+      },
+      "findHeaderInResponse::1::context": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2382
+      },
+      "findHeaderInResponse::1::parser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2379
+      },
+      "findHeaderInResponse::1::parserErrno": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2381
+      },
+      "findHeaderInResponse::1::parserSettings": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2380
+      },
+      "findHeaderInResponse::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2378
+      },
+      "findHeaderInResponse::bufferLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2372
+      },
+      "findHeaderInResponse::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2374
+      },
+      "findHeaderInResponse::pBuffer": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2371
+      },
+      "findHeaderInResponse::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2373
+      },
+      "findHeaderInResponse::pValueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2376
+      },
+      "findHeaderInResponse::pValueLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2375
+      },
+      "findHeaderOnHeaderCompleteCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2339
+      },
+      "findHeaderOnHeaderCompleteCallback::1::pContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2341
+      },
+      "findHeaderOnHeaderCompleteCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2339
+      },
+      "findHeaderValueParserCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2280
+      },
+      "findHeaderValueParserCallback::1::pContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2285
+      },
+      "findHeaderValueParserCallback::1::retCode": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2284
+      },
+      "findHeaderValueParserCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2280
+      },
+      "findHeaderValueParserCallback::pValueLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2281
+      },
+      "findHeaderValueParserCallback::valueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2282
+      },
+      "finish": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 38
+      },
+      "flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 39
+      },
+      "getFinalResponseStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1931
+      },
+      "getFinalResponseStatus::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1935
+      },
+      "getFinalResponseStatus::parsingState": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1931
+      },
+      "getFinalResponseStatus::responseBufferLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1933
+      },
+      "getFinalResponseStatus::totalReceived": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1932
+      },
+      "getTime": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 465
+      },
+      "getZeroTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 565
+      },
+      "headerCount": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 516
+      },
+      "header_state": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 35
+      },
+      "headersLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 343
+      },
+      "hostLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 370
+      },
+      "httpHeaderStrncpy": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1257
+      },
+      "httpHeaderStrncpy::$tmp::tmp_if_expr": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1283
+      },
+      "httpHeaderStrncpy::1::hasError": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1264
+      },
+      "httpHeaderStrncpy::1::i": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1262
+      },
+      "httpHeaderStrncpy::1::pRet": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1263
+      },
+      "httpHeaderStrncpy::isField": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 38
+      },
+      "httpHeaderStrncpy::isField$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1260
+      },
+      "httpHeaderStrncpy::len": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 37
+      },
+      "httpHeaderStrncpy::len$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1259
+      },
+      "httpHeaderStrncpy::pDest": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 35
+      },
+      "httpHeaderStrncpy::pDest$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1257
+      },
+      "httpHeaderStrncpy::pSrc": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 36
+      },
+      "httpHeaderStrncpy::pSrc$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1258
+      },
+      "httpParserOnBodyCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 891
+      },
+      "httpParserOnBodyCallback::1::pNextWriteLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 898
+      },
+      "httpParserOnBodyCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 896
+      },
+      "httpParserOnBodyCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 897
+      },
+      "httpParserOnBodyCallback::1::shouldContinueParse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 895
+      },
+      "httpParserOnBodyCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 893
+      },
+      "httpParserOnBodyCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 891
+      },
+      "httpParserOnBodyCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 892
+      },
+      "httpParserOnHeaderFieldCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 700
+      },
+      "httpParserOnHeaderFieldCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 704
+      },
+      "httpParserOnHeaderFieldCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 705
+      },
+      "httpParserOnHeaderFieldCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 702
+      },
+      "httpParserOnHeaderFieldCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 700
+      },
+      "httpParserOnHeaderFieldCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 701
+      },
+      "httpParserOnHeaderValueCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 757
+      },
+      "httpParserOnHeaderValueCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 761
+      },
+      "httpParserOnHeaderValueCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 759
+      },
+      "httpParserOnHeaderValueCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 757
+      },
+      "httpParserOnHeaderValueCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 758
+      },
+      "httpParserOnHeadersCompleteCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 801
+      },
+      "httpParserOnHeadersCompleteCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 804
+      },
+      "httpParserOnHeadersCompleteCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 805
+      },
+      "httpParserOnHeadersCompleteCallback::1::shouldContinueParse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 803
+      },
+      "httpParserOnHeadersCompleteCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 801
+      },
+      "httpParserOnMessageBeginCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 640
+      },
+      "httpParserOnMessageBeginCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 642
+      },
+      "httpParserOnMessageBeginCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 640
+      },
+      "httpParserOnMessageCompleteCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 968
+      },
+      "httpParserOnMessageCompleteCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 970
+      },
+      "httpParserOnMessageCompleteCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 968
+      },
+      "httpParserOnStatusCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 659
+      },
+      "httpParserOnStatusCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 663
+      },
+      "httpParserOnStatusCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 664
+      },
+      "httpParserOnStatusCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 661
+      },
+      "httpParserOnStatusCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 659
+      },
+      "httpParserOnStatusCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 660
+      },
+      "http_major": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 33
+      },
+      "http_minor": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 34
+      },
+      "initializeParsingContextForFirstResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 987
+      },
+      "initializeParsingContextForFirstResponse::$tmp::return_value_strncmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1017
+      },
+      "initializeParsingContextForFirstResponse::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 987
+      },
+      "initializeParsingContextForFirstResponse::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 988
+      },
+      "isHeadResponse": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 292
+      },
+      "isValidHttpRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 54
+      },
+      "isValidHttpRequestHeaders::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 60
+      },
+      "isValidHttpRequestHeaders::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 56
+      },
+      "isValidHttpRequestHeaders::pRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 54
+      },
+      "isValidHttpRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 89
+      },
+      "isValidHttpRequestInfo::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 95
+      },
+      "isValidHttpRequestInfo::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 97
+      },
+      "isValidHttpRequestInfo::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 91
+      },
+      "isValidHttpRequestInfo::pRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 89
+      },
+      "isValidHttpResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 160
+      },
+      "isValidHttpResponse::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 166
+      },
+      "isValidHttpResponse::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 168
+      },
+      "isValidHttpResponse::$tmp::tmp_if_expr$1": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 169
+      },
+      "isValidHttpResponse::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 162
+      },
+      "isValidHttpResponse::pResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 160
+      },
+      "isValidHttpSendParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 244
+      },
+      "isValidHttpSendParsingContext::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 248
+      },
+      "isValidHttpSendParsingContext::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 249
+      },
+      "isValidHttpSendParsingContext::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 246
+      },
+      "isValidHttpSendParsingContext::pHttpParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 244
+      },
+      "isValidTransportInterface": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 190
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 196
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 196
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr$1": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 198
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr$2": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 198
+      },
+      "isValidTransportInterface::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 192
+      },
+      "isValidTransportInterface::pTransportInterface": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 190
+      },
+      "lastHeaderFieldLen": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 296
+      },
+      "lastHeaderValueLen": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 298
+      },
+      "lenient_flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 36
+      },
+      "llhttpParser": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 288
+      },
+      "llhttpSettings": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 289
+      },
+      "llhttp__internal_s": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 20
+      },
+      "llhttp__internal_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 20
+      },
+      "llhttp_cb": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 324
+      },
+      "llhttp_data_cb": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 323
+      },
+      "llhttp_errno": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 58
+      },
+      "llhttp_errno_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 85
+      },
+      "llhttp_execute": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 432
+      },
+      "llhttp_finish": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 114
+      },
+      "llhttp_finish_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 119
+      },
+      "llhttp_flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 87
+      },
+      "llhttp_flags_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 98
+      },
+      "llhttp_get_errno": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 484
+      },
+      "llhttp_init": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 374
+      },
+      "llhttp_lenient_flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 100
+      },
+      "llhttp_lenient_flags_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 105
+      },
+      "llhttp_method": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 121
+      },
+      "llhttp_method_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 169
+      },
+      "llhttp_settings_init": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 413
+      },
+      "llhttp_settings_s": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 321
+      },
+      "llhttp_settings_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 321
+      },
+      "llhttp_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 320
+      },
+      "llhttp_type": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 107
+      },
+      "llhttp_type_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 112
+      },
+      "mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 32
+      },
+      "mallocCanFail::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 35
+      },
+      "mallocCanFail::size": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 32
+      },
+      "method": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 32
+      },
+      "methodLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 356
+      },
+      "nondet_bool": {
+        "file": "test/cbmc/include/http_cbmc_state.h",
+        "function": null,
+        "line": 47
+      },
+      "onHeaderCallback": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 398
+      },
+      "on_body": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 348
+      },
+      "on_chunk_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 358
+      },
+      "on_chunk_header": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 357
+      },
+      "on_header_field": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 333
+      },
+      "on_header_field_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 363
+      },
+      "on_header_value": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 334
+      },
+      "on_header_value_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 364
+      },
+      "on_headers_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 345
+      },
+      "on_message_begin": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 328
+      },
+      "on_message_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 351
+      },
+      "on_status": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 332
+      },
+      "on_status_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 362
+      },
+      "on_url": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 331
+      },
+      "on_url_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 361
+      },
+      "pBody": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 486
+      },
+      "pBuffer": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 335
+      },
+      "pBufferCur": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 294
+      },
+      "pContext": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 408
+      },
+      "pField": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 222
+      },
+      "pHeaderParsingCallback": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 449
+      },
+      "pHeaders": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 472
+      },
+      "pHost": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 369
+      },
+      "pLastHeaderField": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 295
+      },
+      "pLastHeaderValue": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 297
+      },
+      "pMethod": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 355
+      },
+      "pNetworkContext": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 255
+      },
+      "pPath": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 361
+      },
+      "pResponse": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 291
+      },
+      "pValueLen": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 225
+      },
+      "pValueLoc": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 224
+      },
+      "parseHttpResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1141
+      },
+      "parseHttpResponse::1::parsingStartLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1146
+      },
+      "parseHttpResponse::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1145
+      },
+      "parseHttpResponse::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1141
+      },
+      "parseHttpResponse::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1142
+      },
+      "parseHttpResponse::parseLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1143
+      },
+      "pathLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 362
+      },
+      "processCompleteHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 591
+      },
+      "processCompleteHeader::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 593
+      },
+      "processCompleteHeader::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 591
+      },
+      "processLlhttpError": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1027
+      },
+      "processLlhttpError::$tmp::return_value_llhttp_get_errno": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1036
+      },
+      "processLlhttpError::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1029
+      },
+      "processLlhttpError::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1027
+      },
+      "reason": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 26
+      },
+      "receiveAndParseHttpResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1978
+      },
+      "receiveAndParseHttpResponse::$tmp::return_value": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2041
+      },
+      "receiveAndParseHttpResponse::$tmp::tmp_if_expr": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2072
+      },
+      "receiveAndParseHttpResponse::1::currentReceived": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1984
+      },
+      "receiveAndParseHttpResponse::1::lastRecvTimeMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1987
+      },
+      "receiveAndParseHttpResponse::1::parsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1985
+      },
+      "receiveAndParseHttpResponse::1::retryTimeoutMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1988
+      },
+      "receiveAndParseHttpResponse::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1982
+      },
+      "receiveAndParseHttpResponse::1::shouldParse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1986
+      },
+      "receiveAndParseHttpResponse::1::shouldRecv": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1986
+      },
+      "receiveAndParseHttpResponse::1::timeSinceLastRecvMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1987
+      },
+      "receiveAndParseHttpResponse::1::timeoutReached": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1986
+      },
+      "receiveAndParseHttpResponse::1::totalReceived": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1983
+      },
+      "receiveAndParseHttpResponse::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1980
+      },
+      "receiveAndParseHttpResponse::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1979
+      },
+      "receiveAndParseHttpResponse::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1978
+      },
+      "recv": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 253
+      },
+      "reqFlags": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 377
+      },
+      "respFlags": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 524
+      },
+      "send": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 254
+      },
+      "sendHttpBody": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1910
+      },
+      "sendHttpBody::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1915
+      },
+      "sendHttpBody::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1911
+      },
+      "sendHttpBody::pRequestBodyBuf": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1912
+      },
+      "sendHttpBody::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1910
+      },
+      "sendHttpBody::reqBodyBufLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1913
+      },
+      "sendHttpData": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1760
+      },
+      "sendHttpData::$tmp::return_value": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1823
+      },
+      "sendHttpData::1::bytesRemaining": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1768
+      },
+      "sendHttpData::1::bytesSent": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1767
+      },
+      "sendHttpData::1::lastSendTimeMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1769
+      },
+      "sendHttpData::1::pIndex": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1766
+      },
+      "sendHttpData::1::retryTimeoutMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1770
+      },
+      "sendHttpData::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1765
+      },
+      "sendHttpData::1::timeSinceLastSendMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1769
+      },
+      "sendHttpData::dataLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1763
+      },
+      "sendHttpData::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1761
+      },
+      "sendHttpData::pData": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1762
+      },
+      "sendHttpData::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1760
+      },
+      "sendHttpHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1872
+      },
+      "sendHttpHeaders::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1878
+      },
+      "sendHttpHeaders::1::shouldSendContentLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1879
+      },
+      "sendHttpHeaders::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1873
+      },
+      "sendHttpHeaders::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1874
+      },
+      "sendHttpHeaders::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1872
+      },
+      "sendHttpHeaders::reqBodyLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1875
+      },
+      "sendHttpHeaders::sendFlags": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1876
+      },
+      "sendHttpRequest": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2092
+      },
+      "sendHttpRequest::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2099
+      },
+      "sendHttpRequest::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2093
+      },
+      "sendHttpRequest::pRequestBodyBuf": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2095
+      },
+      "sendHttpRequest::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2094
+      },
+      "sendHttpRequest::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2092
+      },
+      "sendHttpRequest::reqBodyBufLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2096
+      },
+      "sendHttpRequest::sendFlags": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2097
+      },
+      "settings": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 41
+      },
+      "state": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 290
+      },
+      "statusCode": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 502
+      },
+      "status_code": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 40
+      },
+      "strncpy": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 49
+      },
+      "type": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 31
+      },
+      "upgrade": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 37
+      },
+      "valueFound": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 227
+      },
+      "writeRequestLine": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1467
+      },
+      "writeRequestLine::1::pBufferCur": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1474
+      },
+      "writeRequestLine::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1473
+      },
+      "writeRequestLine::1::toAddLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1475
+      },
+      "writeRequestLine::methodLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1469
+      },
+      "writeRequestLine::pMethod": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1468
+      },
+      "writeRequestLine::pPath": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1470
+      },
+      "writeRequestLine::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1467
+      },
+      "writeRequestLine::pathLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1471
+      }
+    }
+  }
+}

--- a/tests/unit-tests/ctags/symbol-legacy.json
+++ b/tests/unit-tests/ctags/symbol-legacy.json
@@ -1,0 +1,1911 @@
+{
+  "viewer-symbol": {
+    "symbols": {
+      "HTTPClient_AddHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1635
+      },
+      "HTTPClient_AddHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1641
+      },
+      "HTTPClient_AddHeader::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1637
+      },
+      "HTTPClient_AddHeader::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1636
+      },
+      "HTTPClient_AddHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1635
+      },
+      "HTTPClient_AddHeader::pValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1638
+      },
+      "HTTPClient_AddHeader::valueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1639
+      },
+      "HTTPClient_AddRangeHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1695
+      },
+      "HTTPClient_AddRangeHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1699
+      },
+      "HTTPClient_AddRangeHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1695
+      },
+      "HTTPClient_AddRangeHeader::rangeEnd": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1697
+      },
+      "HTTPClient_AddRangeHeader::rangeStartOrlastNbytes": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1696
+      },
+      "HTTPClient_AddRangeHeader_harness": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 32
+      },
+      "HTTPClient_AddRangeHeader_harness::$tmp::return_value_isValidHttpRequestHeaders": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 40
+      },
+      "HTTPClient_AddRangeHeader_harness::1::pRequestHeaders": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 34
+      },
+      "HTTPClient_AddRangeHeader_harness::1::rangeEnd": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 36
+      },
+      "HTTPClient_AddRangeHeader_harness::1::rangeStartOrlastNbytes": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 35
+      },
+      "HTTPClient_GetCurrentTimeFunc_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 418
+      },
+      "HTTPClient_InitializeRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1538
+      },
+      "HTTPClient_InitializeRequestHeaders::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1541
+      },
+      "HTTPClient_InitializeRequestHeaders::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1538
+      },
+      "HTTPClient_InitializeRequestHeaders::pRequestInfo": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1539
+      },
+      "HTTPClient_ReadHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2479
+      },
+      "HTTPClient_ReadHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2485
+      },
+      "HTTPClient_ReadHeader::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2481
+      },
+      "HTTPClient_ReadHeader::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2480
+      },
+      "HTTPClient_ReadHeader::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2479
+      },
+      "HTTPClient_ReadHeader::pValueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2483
+      },
+      "HTTPClient_ReadHeader::pValueLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2482
+      },
+      "HTTPClient_ResponseHeaderParsingCallback": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 387
+      },
+      "HTTPClient_ResponseHeaderParsingCallback_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 409
+      },
+      "HTTPClient_Send": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2135
+      },
+      "HTTPClient_Send::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2142
+      },
+      "HTTPClient_Send::pRequestBodyBuf": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2137
+      },
+      "HTTPClient_Send::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2136
+      },
+      "HTTPClient_Send::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2139
+      },
+      "HTTPClient_Send::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2135
+      },
+      "HTTPClient_Send::reqBodyBufLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2138
+      },
+      "HTTPClient_Send::sendFlags": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2140
+      },
+      "HTTPClient_strerror": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2544
+      },
+      "HTTPClient_strerror::1::str": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2546
+      },
+      "HTTPClient_strerror::status": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2544
+      },
+      "HTTPParsingContext": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 286
+      },
+      "HTTPParsingContext_t": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 299
+      },
+      "HTTPParsingState_t": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 213
+      },
+      "HTTPRequestHeaders": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 319
+      },
+      "HTTPRequestHeaders_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 344
+      },
+      "HTTPRequestInfo": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 350
+      },
+      "HTTPRequestInfo_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 378
+      },
+      "HTTPResponse": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 424
+      },
+      "HTTPResponse_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 525
+      },
+      "HTTPStatus": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 161
+      },
+      "HTTPStatus_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 306
+      },
+      "HTTP_ALL_METHOD_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 253
+      },
+      "HTTP_ERRNO_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 171
+      },
+      "HTTP_METHOD_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 199
+      },
+      "NetworkContext": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 188
+      },
+      "NetworkContext_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 189
+      },
+      "RTSP_METHOD_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 236
+      },
+      "TransportInterface": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 251
+      },
+      "TransportInterfaceReceiveStub": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 62
+      },
+      "TransportInterfaceSendStub": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 49
+      },
+      "TransportInterface_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 256
+      },
+      "TransportRecv_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 219
+      },
+      "TransportSend_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 241
+      },
+      "__builtin___strncpy_chk": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 39
+      },
+      "__builtin___strncpy_chk::dest": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 39
+      },
+      "__builtin___strncpy_chk::n": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 41
+      },
+      "__builtin___strncpy_chk::os": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 42
+      },
+      "__builtin___strncpy_chk::src": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 40
+      },
+      "__has_builtin": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 35
+      },
+      "addContentLengthHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1840
+      },
+      "addContentLengthHeader::1::contentLengthValueNumBytes": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1845
+      },
+      "addContentLengthHeader::1::pContentLengthValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1844
+      },
+      "addContentLengthHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1843
+      },
+      "addContentLengthHeader::contentLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1841
+      },
+      "addContentLengthHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1840
+      },
+      "addHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1306
+      },
+      "addHeader::$tmp::return_value_httpHeaderStrncpy": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1350
+      },
+      "addHeader::$tmp::return_value_httpHeaderStrncpy$0": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1367
+      },
+      "addHeader::$tmp::return_value_strncmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1331
+      },
+      "addHeader::1::backtrackHeaderLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1315
+      },
+      "addHeader::1::pBufferCur": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1313
+      },
+      "addHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1312
+      },
+      "addHeader::1::toAddLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1314
+      },
+      "addHeader::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1308
+      },
+      "addHeader::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1307
+      },
+      "addHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1306
+      },
+      "addHeader::pValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1309
+      },
+      "addHeader::valueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1310
+      },
+      "addRangeHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1401
+      },
+      "addRangeHeader::$tmp::return_value_convertInt32ToAscii": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1425
+      },
+      "addRangeHeader::$tmp::return_value_convertInt32ToAscii$0": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1439
+      },
+      "addRangeHeader::1::rangeValueBuffer": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1406
+      },
+      "addRangeHeader::1::rangeValueLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1407
+      },
+      "addRangeHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1405
+      },
+      "addRangeHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1401
+      },
+      "addRangeHeader::rangeEnd": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1403
+      },
+      "addRangeHeader::rangeStartOrlastNbytes": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1402
+      },
+      "allocateFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 270
+      },
+      "allocateFindHeaderContext::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 274
+      },
+      "allocateFindHeaderContext::pFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 270
+      },
+      "allocateHttpReadHeaderParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 254
+      },
+      "allocateHttpReadHeaderParser::$tmp::return_value_allocateFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 264
+      },
+      "allocateHttpReadHeaderParser::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 260
+      },
+      "allocateHttpReadHeaderParser::1::pFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 256
+      },
+      "allocateHttpReadHeaderParser::pHttpParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 254
+      },
+      "allocateHttpRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 38
+      },
+      "allocateHttpRequestHeaders::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 42
+      },
+      "allocateHttpRequestHeaders::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 48
+      },
+      "allocateHttpRequestHeaders::pRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 38
+      },
+      "allocateHttpRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 67
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 71
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 77
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail$1": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 80
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail$2": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 83
+      },
+      "allocateHttpRequestInfo::pRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 67
+      },
+      "allocateHttpResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 103
+      },
+      "allocateHttpResponse::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 109
+      },
+      "allocateHttpResponse::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 115
+      },
+      "allocateHttpResponse::$tmp::return_value_nondet_bool": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 123
+      },
+      "allocateHttpResponse::$tmp::return_value_nondet_bool$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 145
+      },
+      "allocateHttpResponse::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 123
+      },
+      "allocateHttpResponse::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 145
+      },
+      "allocateHttpResponse::1::bodyOffset": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 105
+      },
+      "allocateHttpResponse::1::headerOffset": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 105
+      },
+      "allocateHttpResponse::pResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 103
+      },
+      "allocateHttpSendParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 203
+      },
+      "allocateHttpSendParser::$tmp::return_value_isValidHttpSendParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 214
+      },
+      "allocateHttpSendParser::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 209
+      },
+      "allocateHttpSendParser::1::pHttpParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 205
+      },
+      "allocateHttpSendParser::pHttpParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 203
+      },
+      "allocateHttpSendParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 220
+      },
+      "allocateHttpSendParsingContext::$tmp::return_value_isValidHttpResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 231
+      },
+      "allocateHttpSendParsingContext::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 227
+      },
+      "allocateHttpSendParsingContext::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 231
+      },
+      "allocateHttpSendParsingContext::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 234
+      },
+      "allocateHttpSendParsingContext::1::bufferOffset": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 223
+      },
+      "allocateHttpSendParsingContext::1::pResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 222
+      },
+      "allocateHttpSendParsingContext::pHttpParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 220
+      },
+      "allocateTransportInterface": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 175
+      },
+      "allocateTransportInterface::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 179
+      },
+      "allocateTransportInterface::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 184
+      },
+      "allocateTransportInterface::pTransport": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 175
+      },
+      "bytesToRecv": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 220
+      },
+      "bytesToSend": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 242
+      },
+      "caseInsensitiveStringCmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 572
+      },
+      "caseInsensitiveStringCmp::$tmp::return_value_toupper": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 580
+      },
+      "caseInsensitiveStringCmp::$tmp::return_value_toupper$0": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 580
+      },
+      "caseInsensitiveStringCmp::1::i": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 576
+      },
+      "caseInsensitiveStringCmp::n": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 574
+      },
+      "caseInsensitiveStringCmp::str1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 572
+      },
+      "caseInsensitiveStringCmp::str2": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 573
+      },
+      "convertInt32ToAscii": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1204
+      },
+      "convertInt32ToAscii::1::absoluteValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1214
+      },
+      "convertInt32ToAscii::1::index": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1216
+      },
+      "convertInt32ToAscii::1::isNegative": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1217
+      },
+      "convertInt32ToAscii::1::numOfDigits": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1215
+      },
+      "convertInt32ToAscii::1::temp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1218
+      },
+      "convertInt32ToAscii::bufferLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1206
+      },
+      "convertInt32ToAscii::pBuffer": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1205
+      },
+      "convertInt32ToAscii::value": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1204
+      },
+      "findHeaderContext": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 220
+      },
+      "findHeaderContext_t": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 228
+      },
+      "findHeaderFieldParserCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2238
+      },
+      "findHeaderFieldParserCallback::$tmp::return_value_caseInsensitiveStringCmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2261
+      },
+      "findHeaderFieldParserCallback::$tmp::tmp_if_expr": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2260
+      },
+      "findHeaderFieldParserCallback::1::pContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2242
+      },
+      "findHeaderFieldParserCallback::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2240
+      },
+      "findHeaderFieldParserCallback::pFieldLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2239
+      },
+      "findHeaderFieldParserCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2238
+      },
+      "findHeaderInResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2371
+      },
+      "findHeaderInResponse::1::context": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2382
+      },
+      "findHeaderInResponse::1::parser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2379
+      },
+      "findHeaderInResponse::1::parserErrno": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2381
+      },
+      "findHeaderInResponse::1::parserSettings": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2380
+      },
+      "findHeaderInResponse::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2378
+      },
+      "findHeaderInResponse::bufferLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2372
+      },
+      "findHeaderInResponse::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2374
+      },
+      "findHeaderInResponse::pBuffer": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2371
+      },
+      "findHeaderInResponse::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2373
+      },
+      "findHeaderInResponse::pValueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2376
+      },
+      "findHeaderInResponse::pValueLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2375
+      },
+      "findHeaderOnHeaderCompleteCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2339
+      },
+      "findHeaderOnHeaderCompleteCallback::1::pContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2341
+      },
+      "findHeaderOnHeaderCompleteCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2339
+      },
+      "findHeaderValueParserCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2280
+      },
+      "findHeaderValueParserCallback::1::pContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2285
+      },
+      "findHeaderValueParserCallback::1::retCode": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2284
+      },
+      "findHeaderValueParserCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2280
+      },
+      "findHeaderValueParserCallback::pValueLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2281
+      },
+      "findHeaderValueParserCallback::valueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2282
+      },
+      "getFinalResponseStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1931
+      },
+      "getFinalResponseStatus::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1935
+      },
+      "getFinalResponseStatus::parsingState": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1931
+      },
+      "getFinalResponseStatus::responseBufferLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1933
+      },
+      "getFinalResponseStatus::totalReceived": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1932
+      },
+      "getZeroTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 565
+      },
+      "httpHeaderStrncpy": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1257
+      },
+      "httpHeaderStrncpy::$tmp::tmp_if_expr": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1283
+      },
+      "httpHeaderStrncpy::1::hasError": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1264
+      },
+      "httpHeaderStrncpy::1::i": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1262
+      },
+      "httpHeaderStrncpy::1::pRet": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1263
+      },
+      "httpHeaderStrncpy::isField": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 38
+      },
+      "httpHeaderStrncpy::isField$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1260
+      },
+      "httpHeaderStrncpy::len": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 37
+      },
+      "httpHeaderStrncpy::len$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1259
+      },
+      "httpHeaderStrncpy::pDest": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 35
+      },
+      "httpHeaderStrncpy::pDest$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1257
+      },
+      "httpHeaderStrncpy::pSrc": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 36
+      },
+      "httpHeaderStrncpy::pSrc$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1258
+      },
+      "httpParserOnBodyCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 891
+      },
+      "httpParserOnBodyCallback::1::pNextWriteLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 898
+      },
+      "httpParserOnBodyCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 896
+      },
+      "httpParserOnBodyCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 897
+      },
+      "httpParserOnBodyCallback::1::shouldContinueParse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 895
+      },
+      "httpParserOnBodyCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 893
+      },
+      "httpParserOnBodyCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 891
+      },
+      "httpParserOnBodyCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 892
+      },
+      "httpParserOnHeaderFieldCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 700
+      },
+      "httpParserOnHeaderFieldCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 704
+      },
+      "httpParserOnHeaderFieldCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 705
+      },
+      "httpParserOnHeaderFieldCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 702
+      },
+      "httpParserOnHeaderFieldCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 700
+      },
+      "httpParserOnHeaderFieldCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 701
+      },
+      "httpParserOnHeaderValueCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 757
+      },
+      "httpParserOnHeaderValueCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 761
+      },
+      "httpParserOnHeaderValueCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 759
+      },
+      "httpParserOnHeaderValueCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 757
+      },
+      "httpParserOnHeaderValueCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 758
+      },
+      "httpParserOnHeadersCompleteCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 801
+      },
+      "httpParserOnHeadersCompleteCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 804
+      },
+      "httpParserOnHeadersCompleteCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 805
+      },
+      "httpParserOnHeadersCompleteCallback::1::shouldContinueParse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 803
+      },
+      "httpParserOnHeadersCompleteCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 801
+      },
+      "httpParserOnMessageBeginCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 640
+      },
+      "httpParserOnMessageBeginCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 642
+      },
+      "httpParserOnMessageBeginCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 640
+      },
+      "httpParserOnMessageCompleteCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 968
+      },
+      "httpParserOnMessageCompleteCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 970
+      },
+      "httpParserOnMessageCompleteCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 968
+      },
+      "httpParserOnStatusCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 659
+      },
+      "httpParserOnStatusCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 663
+      },
+      "httpParserOnStatusCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 664
+      },
+      "httpParserOnStatusCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 661
+      },
+      "httpParserOnStatusCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 659
+      },
+      "httpParserOnStatusCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 660
+      },
+      "initializeParsingContextForFirstResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 987
+      },
+      "initializeParsingContextForFirstResponse::$tmp::return_value_strncmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1017
+      },
+      "initializeParsingContextForFirstResponse::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 987
+      },
+      "initializeParsingContextForFirstResponse::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 988
+      },
+      "isValidHttpRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 54
+      },
+      "isValidHttpRequestHeaders::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 60
+      },
+      "isValidHttpRequestHeaders::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 56
+      },
+      "isValidHttpRequestHeaders::pRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 54
+      },
+      "isValidHttpRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 89
+      },
+      "isValidHttpRequestInfo::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 95
+      },
+      "isValidHttpRequestInfo::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 97
+      },
+      "isValidHttpRequestInfo::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 91
+      },
+      "isValidHttpRequestInfo::pRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 89
+      },
+      "isValidHttpResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 160
+      },
+      "isValidHttpResponse::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 166
+      },
+      "isValidHttpResponse::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 168
+      },
+      "isValidHttpResponse::$tmp::tmp_if_expr$1": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 169
+      },
+      "isValidHttpResponse::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 162
+      },
+      "isValidHttpResponse::pResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 160
+      },
+      "isValidHttpSendParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 244
+      },
+      "isValidHttpSendParsingContext::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 248
+      },
+      "isValidHttpSendParsingContext::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 249
+      },
+      "isValidHttpSendParsingContext::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 246
+      },
+      "isValidHttpSendParsingContext::pHttpParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 244
+      },
+      "isValidTransportInterface": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 190
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 196
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 196
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr$1": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 198
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr$2": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 198
+      },
+      "isValidTransportInterface::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 192
+      },
+      "isValidTransportInterface::pTransportInterface": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 190
+      },
+      "length": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 323
+      },
+      "llhttp__internal_s": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 20
+      },
+      "llhttp__internal_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 20
+      },
+      "llhttp_cb": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 324
+      },
+      "llhttp_data_cb": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 323
+      },
+      "llhttp_errno": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 58
+      },
+      "llhttp_errno_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 85
+      },
+      "llhttp_execute": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 432
+      },
+      "llhttp_finish": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 114
+      },
+      "llhttp_finish_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 119
+      },
+      "llhttp_flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 87
+      },
+      "llhttp_flags_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 98
+      },
+      "llhttp_get_errno": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 484
+      },
+      "llhttp_init": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 374
+      },
+      "llhttp_lenient_flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 100
+      },
+      "llhttp_lenient_flags_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 105
+      },
+      "llhttp_method": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 121
+      },
+      "llhttp_method_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 169
+      },
+      "llhttp_settings_init": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 413
+      },
+      "llhttp_settings_s": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 321
+      },
+      "llhttp_settings_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 321
+      },
+      "llhttp_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 320
+      },
+      "llhttp_type": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 107
+      },
+      "llhttp_type_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 112
+      },
+      "mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 32
+      },
+      "mallocCanFail::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 35
+      },
+      "mallocCanFail::size": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 32
+      },
+      "nondet_bool": {
+        "file": "test/cbmc/include/http_cbmc_state.h",
+        "function": null,
+        "line": 47
+      },
+      "parseHttpResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1141
+      },
+      "parseHttpResponse::1::parsingStartLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1146
+      },
+      "parseHttpResponse::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1145
+      },
+      "parseHttpResponse::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1141
+      },
+      "parseHttpResponse::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1142
+      },
+      "parseHttpResponse::parseLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1143
+      },
+      "processCompleteHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 591
+      },
+      "processCompleteHeader::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 593
+      },
+      "processCompleteHeader::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 591
+      },
+      "processLlhttpError": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1027
+      },
+      "processLlhttpError::$tmp::return_value_llhttp_get_errno": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1036
+      },
+      "processLlhttpError::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1029
+      },
+      "processLlhttpError::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1027
+      },
+      "receiveAndParseHttpResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1978
+      },
+      "receiveAndParseHttpResponse::$tmp::return_value": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2041
+      },
+      "receiveAndParseHttpResponse::$tmp::tmp_if_expr": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2072
+      },
+      "receiveAndParseHttpResponse::1::currentReceived": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1984
+      },
+      "receiveAndParseHttpResponse::1::lastRecvTimeMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1987
+      },
+      "receiveAndParseHttpResponse::1::parsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1985
+      },
+      "receiveAndParseHttpResponse::1::retryTimeoutMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1988
+      },
+      "receiveAndParseHttpResponse::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1982
+      },
+      "receiveAndParseHttpResponse::1::shouldParse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1986
+      },
+      "receiveAndParseHttpResponse::1::shouldRecv": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1986
+      },
+      "receiveAndParseHttpResponse::1::timeSinceLastRecvMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1987
+      },
+      "receiveAndParseHttpResponse::1::timeoutReached": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1986
+      },
+      "receiveAndParseHttpResponse::1::totalReceived": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1983
+      },
+      "receiveAndParseHttpResponse::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1980
+      },
+      "receiveAndParseHttpResponse::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1979
+      },
+      "receiveAndParseHttpResponse::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1978
+      },
+      "sendHttpBody": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1910
+      },
+      "sendHttpBody::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1915
+      },
+      "sendHttpBody::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1911
+      },
+      "sendHttpBody::pRequestBodyBuf": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1912
+      },
+      "sendHttpBody::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1910
+      },
+      "sendHttpBody::reqBodyBufLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1913
+      },
+      "sendHttpData": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1760
+      },
+      "sendHttpData::$tmp::return_value": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1823
+      },
+      "sendHttpData::1::bytesRemaining": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1768
+      },
+      "sendHttpData::1::bytesSent": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1767
+      },
+      "sendHttpData::1::lastSendTimeMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1769
+      },
+      "sendHttpData::1::pIndex": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1766
+      },
+      "sendHttpData::1::retryTimeoutMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1770
+      },
+      "sendHttpData::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1765
+      },
+      "sendHttpData::1::timeSinceLastSendMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1769
+      },
+      "sendHttpData::dataLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1763
+      },
+      "sendHttpData::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1761
+      },
+      "sendHttpData::pData": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1762
+      },
+      "sendHttpData::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1760
+      },
+      "sendHttpHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1872
+      },
+      "sendHttpHeaders::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1878
+      },
+      "sendHttpHeaders::1::shouldSendContentLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1879
+      },
+      "sendHttpHeaders::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1873
+      },
+      "sendHttpHeaders::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1874
+      },
+      "sendHttpHeaders::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1872
+      },
+      "sendHttpHeaders::reqBodyLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1875
+      },
+      "sendHttpHeaders::sendFlags": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1876
+      },
+      "sendHttpRequest": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2092
+      },
+      "sendHttpRequest::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2099
+      },
+      "sendHttpRequest::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2093
+      },
+      "sendHttpRequest::pRequestBodyBuf": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2095
+      },
+      "sendHttpRequest::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2094
+      },
+      "sendHttpRequest::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2092
+      },
+      "sendHttpRequest::reqBodyBufLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2096
+      },
+      "sendHttpRequest::sendFlags": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2097
+      },
+      "strncpy": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 49
+      },
+      "void": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 418
+      },
+      "writeRequestLine": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1467
+      },
+      "writeRequestLine::1::pBufferCur": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1474
+      },
+      "writeRequestLine::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1473
+      },
+      "writeRequestLine::1::toAddLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1475
+      },
+      "writeRequestLine::methodLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1469
+      },
+      "writeRequestLine::pMethod": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1468
+      },
+      "writeRequestLine::pPath": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1470
+      },
+      "writeRequestLine::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1467
+      },
+      "writeRequestLine::pathLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1471
+      }
+    }
+  }
+}

--- a/tests/unit-tests/ctags/symbol-universal.json
+++ b/tests/unit-tests/ctags/symbol-universal.json
@@ -1,0 +1,3131 @@
+{
+  "viewer-symbol": {
+    "symbols": {
+      "CARRIAGE_RETURN_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 74
+      },
+      "COLON_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 76
+      },
+      "CORE_HTTP_CLIENT_H_": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 29
+      },
+      "CORE_HTTP_CLIENT_PRIVATE_H_": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 29
+      },
+      "DASH_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 70
+      },
+      "DASH_CHARACTER_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 71
+      },
+      "F_CHUNKED": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 91
+      },
+      "F_CONNECTION_CLOSE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 89
+      },
+      "F_CONNECTION_KEEP_ALIVE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 88
+      },
+      "F_CONNECTION_UPGRADE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 90
+      },
+      "F_CONTENT_LENGTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 93
+      },
+      "F_SKIPBODY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 94
+      },
+      "F_TRAILING": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 95
+      },
+      "F_TRANSFER_ENCODING": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 96
+      },
+      "F_UPGRADE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 92
+      },
+      "HPE_CB_CHUNK_COMPLETE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 79
+      },
+      "HPE_CB_CHUNK_HEADER": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 78
+      },
+      "HPE_CB_HEADERS_COMPLETE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 76
+      },
+      "HPE_CB_MESSAGE_BEGIN": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 75
+      },
+      "HPE_CB_MESSAGE_COMPLETE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 77
+      },
+      "HPE_CLOSED_CONNECTION": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 64
+      },
+      "HPE_INTERNAL": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 60
+      },
+      "HPE_INVALID_CHUNK_SIZE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 71
+      },
+      "HPE_INVALID_CONSTANT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 67
+      },
+      "HPE_INVALID_CONTENT_LENGTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 70
+      },
+      "HPE_INVALID_EOF_STATE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 73
+      },
+      "HPE_INVALID_HEADER_TOKEN": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 69
+      },
+      "HPE_INVALID_METHOD": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 65
+      },
+      "HPE_INVALID_STATUS": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 72
+      },
+      "HPE_INVALID_TRANSFER_ENCODING": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 74
+      },
+      "HPE_INVALID_URL": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 66
+      },
+      "HPE_INVALID_VERSION": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 68
+      },
+      "HPE_LF_EXPECTED": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 62
+      },
+      "HPE_OK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 59
+      },
+      "HPE_PAUSED": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 80
+      },
+      "HPE_PAUSED_H2_UPGRADE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 82
+      },
+      "HPE_PAUSED_UPGRADE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 81
+      },
+      "HPE_STRICT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 61
+      },
+      "HPE_UNEXPECTED_CONTENT_LENGTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 63
+      },
+      "HPE_USER": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 83
+      },
+      "HTTPClient_AddHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1635
+      },
+      "HTTPClient_AddHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1641
+      },
+      "HTTPClient_AddHeader::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1637
+      },
+      "HTTPClient_AddHeader::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1636
+      },
+      "HTTPClient_AddHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1635
+      },
+      "HTTPClient_AddHeader::pValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1638
+      },
+      "HTTPClient_AddHeader::valueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1639
+      },
+      "HTTPClient_AddRangeHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1695
+      },
+      "HTTPClient_AddRangeHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1699
+      },
+      "HTTPClient_AddRangeHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1695
+      },
+      "HTTPClient_AddRangeHeader::rangeEnd": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1697
+      },
+      "HTTPClient_AddRangeHeader::rangeStartOrlastNbytes": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1696
+      },
+      "HTTPClient_AddRangeHeader_harness": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 32
+      },
+      "HTTPClient_AddRangeHeader_harness::$tmp::return_value_isValidHttpRequestHeaders": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 40
+      },
+      "HTTPClient_AddRangeHeader_harness::1::pRequestHeaders": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 34
+      },
+      "HTTPClient_AddRangeHeader_harness::1::rangeEnd": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 36
+      },
+      "HTTPClient_AddRangeHeader_harness::1::rangeStartOrlastNbytes": {
+        "file": "test/cbmc/proofs/HTTPClient_AddRangeHeader/HTTPClient_AddRangeHeader_harness.c",
+        "function": null,
+        "line": 35
+      },
+      "HTTPClient_GetCurrentTimeFunc_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 418
+      },
+      "HTTPClient_InitializeRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1538
+      },
+      "HTTPClient_InitializeRequestHeaders::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1541
+      },
+      "HTTPClient_InitializeRequestHeaders::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1538
+      },
+      "HTTPClient_InitializeRequestHeaders::pRequestInfo": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1539
+      },
+      "HTTPClient_ReadHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2479
+      },
+      "HTTPClient_ReadHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2485
+      },
+      "HTTPClient_ReadHeader::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2481
+      },
+      "HTTPClient_ReadHeader::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2480
+      },
+      "HTTPClient_ReadHeader::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2479
+      },
+      "HTTPClient_ReadHeader::pValueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2483
+      },
+      "HTTPClient_ReadHeader::pValueLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2482
+      },
+      "HTTPClient_ResponseHeaderParsingCallback": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 387
+      },
+      "HTTPClient_ResponseHeaderParsingCallback_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 409
+      },
+      "HTTPClient_Send": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2135
+      },
+      "HTTPClient_Send::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2142
+      },
+      "HTTPClient_Send::pRequestBodyBuf": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2137
+      },
+      "HTTPClient_Send::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2136
+      },
+      "HTTPClient_Send::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2139
+      },
+      "HTTPClient_Send::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2135
+      },
+      "HTTPClient_Send::reqBodyBufLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2138
+      },
+      "HTTPClient_Send::sendFlags": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2140
+      },
+      "HTTPClient_strerror": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2544
+      },
+      "HTTPClient_strerror::1::str": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2546
+      },
+      "HTTPClient_strerror::status": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2544
+      },
+      "HTTPHeaderNotFound": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 296
+      },
+      "HTTPInsufficientMemory": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 224
+      },
+      "HTTPInvalidParameter": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 185
+      },
+      "HTTPInvalidResponse": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 305
+      },
+      "HTTPNetworkError": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 193
+      },
+      "HTTPNoResponse": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 212
+      },
+      "HTTPParserInternalError": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 288
+      },
+      "HTTPParsingContext": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 286
+      },
+      "HTTPParsingContext_t": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 299
+      },
+      "HTTPParsingState_t": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 213
+      },
+      "HTTPPartialResponse": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 201
+      },
+      "HTTPRequestHeaders": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 319
+      },
+      "HTTPRequestHeaders_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 344
+      },
+      "HTTPRequestInfo": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 350
+      },
+      "HTTPRequestInfo_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 378
+      },
+      "HTTPResponse": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 424
+      },
+      "HTTPResponse_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 525
+      },
+      "HTTPSecurityAlertExtraneousResponseData": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 233
+      },
+      "HTTPSecurityAlertInvalidCharacter": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 269
+      },
+      "HTTPSecurityAlertInvalidChunkHeader": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 241
+      },
+      "HTTPSecurityAlertInvalidContentLength": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 279
+      },
+      "HTTPSecurityAlertInvalidProtocolVersion": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 250
+      },
+      "HTTPSecurityAlertInvalidStatusCode": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 259
+      },
+      "HTTPStatus": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 161
+      },
+      "HTTPStatus_t": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 306
+      },
+      "HTTPSuccess": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 173
+      },
+      "HTTP_ACL": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 141
+      },
+      "HTTP_ALL_METHOD_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 253
+      },
+      "HTTP_ANNOUNCE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 158
+      },
+      "HTTP_BIND": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 138
+      },
+      "HTTP_BOTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 108
+      },
+      "HTTP_CBMC_STATE_H_": {
+        "file": "test/cbmc/include/http_cbmc_state.h",
+        "function": null,
+        "line": 29
+      },
+      "HTTP_CHECKOUT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 144
+      },
+      "HTTP_CONNECT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 127
+      },
+      "HTTP_CONNECTION_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 99
+      },
+      "HTTP_CONNECTION_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 100
+      },
+      "HTTP_CONNECTION_KEEP_ALIVE_VALUE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 110
+      },
+      "HTTP_CONNECTION_KEEP_ALIVE_VALUE_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 116
+      },
+      "HTTP_CONTENT_LENGTH_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 101
+      },
+      "HTTP_CONTENT_LENGTH_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 102
+      },
+      "HTTP_COPY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 130
+      },
+      "HTTP_DELETE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 122
+      },
+      "HTTP_DESCRIBE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 157
+      },
+      "HTTP_EMPTY_PATH": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 58
+      },
+      "HTTP_EMPTY_PATH_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 59
+      },
+      "HTTP_ERRNO_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 171
+      },
+      "HTTP_FINISH_SAFE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 115
+      },
+      "HTTP_FINISH_SAFE_WITH_CB": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 116
+      },
+      "HTTP_FINISH_UNSAFE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 117
+      },
+      "HTTP_FLUSH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 167
+      },
+      "HTTP_GET": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 123
+      },
+      "HTTP_GET_PARAMETER": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 163
+      },
+      "HTTP_HEAD": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 124
+      },
+      "HTTP_HEADER_END_INDICATOR": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 64
+      },
+      "HTTP_HEADER_END_INDICATOR_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 65
+      },
+      "HTTP_HEADER_FIELD_SEPARATOR": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 66
+      },
+      "HTTP_HEADER_FIELD_SEPARATOR_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 67
+      },
+      "HTTP_HEADER_LINE_SEPARATOR": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 62
+      },
+      "HTTP_HEADER_LINE_SEPARATOR_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 63
+      },
+      "HTTP_HEADER_STRNCPY_IS_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 88
+      },
+      "HTTP_HEADER_STRNCPY_IS_VALUE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 82
+      },
+      "HTTP_HOST_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 94
+      },
+      "HTTP_HOST_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 95
+      },
+      "HTTP_LINK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 153
+      },
+      "HTTP_LOCK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 131
+      },
+      "HTTP_MAX_CONTENT_LENGTH_HEADER_LENGTH": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 71
+      },
+      "HTTP_MAX_RANGE_REQUEST_VALUE_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 157
+      },
+      "HTTP_MERGE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 145
+      },
+      "HTTP_METHOD_GET": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 60
+      },
+      "HTTP_METHOD_HEAD": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 63
+      },
+      "HTTP_METHOD_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 199
+      },
+      "HTTP_METHOD_POST": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 62
+      },
+      "HTTP_METHOD_PUT": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 61
+      },
+      "HTTP_MINIMUM_REQUEST_LINE_LENGTH": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 202
+      },
+      "HTTP_MKACTIVITY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 143
+      },
+      "HTTP_MKCALENDAR": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 152
+      },
+      "HTTP_MKCOL": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 132
+      },
+      "HTTP_MOVE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 133
+      },
+      "HTTP_MSEARCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 146
+      },
+      "HTTP_NOTIFY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 147
+      },
+      "HTTP_OPTIONS": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 128
+      },
+      "HTTP_PARSING_COMPLETE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 212
+      },
+      "HTTP_PARSING_INCOMPLETE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 211
+      },
+      "HTTP_PARSING_NONE": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 210
+      },
+      "HTTP_PATCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 150
+      },
+      "HTTP_PAUSE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 161
+      },
+      "HTTP_PLAY": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 160
+      },
+      "HTTP_POST": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 125
+      },
+      "HTTP_PRI": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 156
+      },
+      "HTTP_PROPFIND": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 134
+      },
+      "HTTP_PROPPATCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 135
+      },
+      "HTTP_PROTOCOL_VERSION": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 52
+      },
+      "HTTP_PROTOCOL_VERSION_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 53
+      },
+      "HTTP_PURGE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 151
+      },
+      "HTTP_PUT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 126
+      },
+      "HTTP_RANGE_REQUEST_END_OF_FILE": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 155
+      },
+      "HTTP_RANGE_REQUEST_HEADER_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 124
+      },
+      "HTTP_RANGE_REQUEST_HEADER_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 130
+      },
+      "HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 136
+      },
+      "HTTP_RANGE_REQUEST_HEADER_VALUE_PREFIX_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 142
+      },
+      "HTTP_REBIND": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 139
+      },
+      "HTTP_RECORD": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 166
+      },
+      "HTTP_REDIRECT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 165
+      },
+      "HTTP_REPORT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 142
+      },
+      "HTTP_REQUEST": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 109
+      },
+      "HTTP_REQUEST_KEEP_ALIVE_FLAG": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 112
+      },
+      "HTTP_RESPONSE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 110
+      },
+      "HTTP_RESPONSE_CONNECTION_CLOSE_FLAG": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 133
+      },
+      "HTTP_RESPONSE_CONNECTION_KEEP_ALIVE_FLAG": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 141
+      },
+      "HTTP_SEARCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 136
+      },
+      "HTTP_SEND_DISABLE_CONTENT_LENGTH_FLAG": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 90
+      },
+      "HTTP_SETUP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 159
+      },
+      "HTTP_SET_PARAMETER": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 164
+      },
+      "HTTP_SOURCE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 155
+      },
+      "HTTP_SUBSCRIBE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 148
+      },
+      "HTTP_TEARDOWN": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 162
+      },
+      "HTTP_TRACE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 129
+      },
+      "HTTP_UNBIND": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 140
+      },
+      "HTTP_UNLINK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 154
+      },
+      "HTTP_UNLOCK": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 137
+      },
+      "HTTP_UNSUBSCRIBE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 149
+      },
+      "HTTP_USER_AGENT_FIELD": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 92
+      },
+      "HTTP_USER_AGENT_FIELD_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 93
+      },
+      "HTTP_USER_AGENT_VALUE_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 96
+      },
+      "INCLUDE_LLHTTP_API_H_": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 308
+      },
+      "INCLUDE_LLHTTP_H_": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 2
+      },
+      "INCLUDE_LLHTTP_ITSELF_H_": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 13
+      },
+      "LENIENT_CHUNKED_LENGTH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 102
+      },
+      "LENIENT_HEADERS": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 101
+      },
+      "LENIENT_KEEP_ALIVE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 103
+      },
+      "LINEFEED_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 75
+      },
+      "LLHTTP_CONTINUE_PARSING": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 165
+      },
+      "LLHTTP_EXPORT": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 315
+      },
+      "LLHTTP_STOP_PARSING": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 171
+      },
+      "LLHTTP_STOP_PARSING_NO_BODY": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 177
+      },
+      "LLHTTP_STOP_PARSING_NO_HEADER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 186
+      },
+      "LLHTTP_STRICT_MODE": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 9
+      },
+      "LLHTTP_VERSION_MAJOR": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 4
+      },
+      "LLHTTP_VERSION_MINOR": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 5
+      },
+      "LLHTTP_VERSION_PATCH": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 6
+      },
+      "LLLLHTTP_C_HEADERS_": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 53
+      },
+      "MAX_INT32_NO_OF_DECIMAL_DIGITS": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 149
+      },
+      "MAX_TRIES": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 37
+      },
+      "NetworkContext": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 188
+      },
+      "NetworkContext_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 189
+      },
+      "RTSP_METHOD_MAP": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 236
+      },
+      "SPACE_CHARACTER": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 68
+      },
+      "SPACE_CHARACTER_LEN": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 69
+      },
+      "TRANSPORT_INTERFACE_H_": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 29
+      },
+      "TRANSPORT_INTERFACE_STUBS_H_": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 30
+      },
+      "TransportInterface": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 251
+      },
+      "TransportInterfaceReceiveStub": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 62
+      },
+      "TransportInterfaceSendStub": {
+        "file": "test/cbmc/include/transport_interface_stubs.h",
+        "function": null,
+        "line": 49
+      },
+      "TransportInterface_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 256
+      },
+      "TransportRecv_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 219
+      },
+      "TransportSend_t": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 241
+      },
+      "__builtin___strncpy_chk": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 39
+      },
+      "__builtin___strncpy_chk::dest": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 39
+      },
+      "__builtin___strncpy_chk::n": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 41
+      },
+      "__builtin___strncpy_chk::os": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 42
+      },
+      "__builtin___strncpy_chk::src": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 40
+      },
+      "__has_builtin": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 35
+      },
+      "_current": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 29
+      },
+      "_index": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 22
+      },
+      "_span_cb0": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 24
+      },
+      "_span_pos0": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 23
+      },
+      "addContentLengthHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1840
+      },
+      "addContentLengthHeader::1::contentLengthValueNumBytes": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1845
+      },
+      "addContentLengthHeader::1::pContentLengthValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1844
+      },
+      "addContentLengthHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1843
+      },
+      "addContentLengthHeader::contentLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1841
+      },
+      "addContentLengthHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1840
+      },
+      "addHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1306
+      },
+      "addHeader::$tmp::return_value_httpHeaderStrncpy": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1350
+      },
+      "addHeader::$tmp::return_value_httpHeaderStrncpy$0": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1367
+      },
+      "addHeader::$tmp::return_value_strncmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1331
+      },
+      "addHeader::1::backtrackHeaderLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1315
+      },
+      "addHeader::1::pBufferCur": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1313
+      },
+      "addHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1312
+      },
+      "addHeader::1::toAddLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1314
+      },
+      "addHeader::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1308
+      },
+      "addHeader::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1307
+      },
+      "addHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1306
+      },
+      "addHeader::pValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1309
+      },
+      "addHeader::valueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1310
+      },
+      "addRangeHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1401
+      },
+      "addRangeHeader::$tmp::return_value_convertInt32ToAscii": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1425
+      },
+      "addRangeHeader::$tmp::return_value_convertInt32ToAscii$0": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1439
+      },
+      "addRangeHeader::1::rangeValueBuffer": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1406
+      },
+      "addRangeHeader::1::rangeValueLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1407
+      },
+      "addRangeHeader::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1405
+      },
+      "addRangeHeader::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1401
+      },
+      "addRangeHeader::rangeEnd": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1403
+      },
+      "addRangeHeader::rangeStartOrlastNbytes": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1402
+      },
+      "allocateFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 270
+      },
+      "allocateFindHeaderContext::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 274
+      },
+      "allocateFindHeaderContext::pFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 270
+      },
+      "allocateHttpReadHeaderParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 254
+      },
+      "allocateHttpReadHeaderParser::$tmp::return_value_allocateFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 264
+      },
+      "allocateHttpReadHeaderParser::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 260
+      },
+      "allocateHttpReadHeaderParser::1::pFindHeaderContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 256
+      },
+      "allocateHttpReadHeaderParser::pHttpParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 254
+      },
+      "allocateHttpRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 38
+      },
+      "allocateHttpRequestHeaders::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 42
+      },
+      "allocateHttpRequestHeaders::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 48
+      },
+      "allocateHttpRequestHeaders::pRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 38
+      },
+      "allocateHttpRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 67
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 71
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 77
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail$1": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 80
+      },
+      "allocateHttpRequestInfo::$tmp::return_value_mallocCanFail$2": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 83
+      },
+      "allocateHttpRequestInfo::pRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 67
+      },
+      "allocateHttpResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 103
+      },
+      "allocateHttpResponse::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 109
+      },
+      "allocateHttpResponse::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 115
+      },
+      "allocateHttpResponse::$tmp::return_value_nondet_bool": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 123
+      },
+      "allocateHttpResponse::$tmp::return_value_nondet_bool$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 145
+      },
+      "allocateHttpResponse::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 123
+      },
+      "allocateHttpResponse::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 145
+      },
+      "allocateHttpResponse::1::bodyOffset": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 105
+      },
+      "allocateHttpResponse::1::headerOffset": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 105
+      },
+      "allocateHttpResponse::pResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 103
+      },
+      "allocateHttpSendParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 203
+      },
+      "allocateHttpSendParser::$tmp::return_value_isValidHttpSendParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 214
+      },
+      "allocateHttpSendParser::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 209
+      },
+      "allocateHttpSendParser::1::pHttpParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 205
+      },
+      "allocateHttpSendParser::pHttpParser": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 203
+      },
+      "allocateHttpSendParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 220
+      },
+      "allocateHttpSendParsingContext::$tmp::return_value_isValidHttpResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 231
+      },
+      "allocateHttpSendParsingContext::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 227
+      },
+      "allocateHttpSendParsingContext::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 231
+      },
+      "allocateHttpSendParsingContext::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 234
+      },
+      "allocateHttpSendParsingContext::1::bufferOffset": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 223
+      },
+      "allocateHttpSendParsingContext::1::pResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 222
+      },
+      "allocateHttpSendParsingContext::pHttpParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 220
+      },
+      "allocateTransportInterface": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 175
+      },
+      "allocateTransportInterface::$tmp::return_value_mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 179
+      },
+      "allocateTransportInterface::$tmp::return_value_mallocCanFail$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 184
+      },
+      "allocateTransportInterface::pTransport": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 175
+      },
+      "bodyLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 493
+      },
+      "bufferLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 336
+      },
+      "caseInsensitiveStringCmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 572
+      },
+      "caseInsensitiveStringCmp::$tmp::return_value_toupper": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 580
+      },
+      "caseInsensitiveStringCmp::$tmp::return_value_toupper$0": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 580
+      },
+      "caseInsensitiveStringCmp::1::i": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 576
+      },
+      "caseInsensitiveStringCmp::n": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 574
+      },
+      "caseInsensitiveStringCmp::str1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 572
+      },
+      "caseInsensitiveStringCmp::str2": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 573
+      },
+      "contentLength": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 509
+      },
+      "content_length": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 30
+      },
+      "convertInt32ToAscii": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1204
+      },
+      "convertInt32ToAscii::1::absoluteValue": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1214
+      },
+      "convertInt32ToAscii::1::index": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1216
+      },
+      "convertInt32ToAscii::1::isNegative": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1217
+      },
+      "convertInt32ToAscii::1::numOfDigits": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1215
+      },
+      "convertInt32ToAscii::1::temp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1218
+      },
+      "convertInt32ToAscii::bufferLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1206
+      },
+      "convertInt32ToAscii::pBuffer": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1205
+      },
+      "convertInt32ToAscii::value": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1204
+      },
+      "data": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 28
+      },
+      "error": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 25
+      },
+      "error_pos": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 27
+      },
+      "fieldFound": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 226
+      },
+      "fieldLen": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 223
+      },
+      "filler": {
+        "file": "test/cbmc/include/http_cbmc_state.h",
+        "function": null,
+        "line": 41
+      },
+      "findHeaderContext": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 220
+      },
+      "findHeaderContext_t": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 228
+      },
+      "findHeaderFieldParserCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2238
+      },
+      "findHeaderFieldParserCallback::$tmp::return_value_caseInsensitiveStringCmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2261
+      },
+      "findHeaderFieldParserCallback::$tmp::tmp_if_expr": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2260
+      },
+      "findHeaderFieldParserCallback::1::pContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2242
+      },
+      "findHeaderFieldParserCallback::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2240
+      },
+      "findHeaderFieldParserCallback::pFieldLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2239
+      },
+      "findHeaderFieldParserCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2238
+      },
+      "findHeaderInResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2371
+      },
+      "findHeaderInResponse::1::context": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2382
+      },
+      "findHeaderInResponse::1::parser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2379
+      },
+      "findHeaderInResponse::1::parserErrno": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2381
+      },
+      "findHeaderInResponse::1::parserSettings": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2380
+      },
+      "findHeaderInResponse::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2378
+      },
+      "findHeaderInResponse::bufferLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2372
+      },
+      "findHeaderInResponse::fieldLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2374
+      },
+      "findHeaderInResponse::pBuffer": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2371
+      },
+      "findHeaderInResponse::pField": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2373
+      },
+      "findHeaderInResponse::pValueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2376
+      },
+      "findHeaderInResponse::pValueLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2375
+      },
+      "findHeaderOnHeaderCompleteCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2339
+      },
+      "findHeaderOnHeaderCompleteCallback::1::pContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2341
+      },
+      "findHeaderOnHeaderCompleteCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2339
+      },
+      "findHeaderValueParserCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2280
+      },
+      "findHeaderValueParserCallback::1::pContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2285
+      },
+      "findHeaderValueParserCallback::1::retCode": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2284
+      },
+      "findHeaderValueParserCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2280
+      },
+      "findHeaderValueParserCallback::pValueLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2281
+      },
+      "findHeaderValueParserCallback::valueLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2282
+      },
+      "finish": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 38
+      },
+      "flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 39
+      },
+      "getFinalResponseStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1931
+      },
+      "getFinalResponseStatus::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1935
+      },
+      "getFinalResponseStatus::parsingState": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1931
+      },
+      "getFinalResponseStatus::responseBufferLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1933
+      },
+      "getFinalResponseStatus::totalReceived": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1932
+      },
+      "getTime": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 465
+      },
+      "getZeroTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 565
+      },
+      "headerCount": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 516
+      },
+      "header_state": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 35
+      },
+      "headersLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 343
+      },
+      "hostLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 370
+      },
+      "httpHeaderStrncpy": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1257
+      },
+      "httpHeaderStrncpy::$tmp::tmp_if_expr": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1283
+      },
+      "httpHeaderStrncpy::1::hasError": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1264
+      },
+      "httpHeaderStrncpy::1::i": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1262
+      },
+      "httpHeaderStrncpy::1::pRet": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1263
+      },
+      "httpHeaderStrncpy::isField": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 38
+      },
+      "httpHeaderStrncpy::isField$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1260
+      },
+      "httpHeaderStrncpy::len": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 37
+      },
+      "httpHeaderStrncpy::len$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1259
+      },
+      "httpHeaderStrncpy::pDest": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 35
+      },
+      "httpHeaderStrncpy::pDest$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1257
+      },
+      "httpHeaderStrncpy::pSrc": {
+        "file": "test/cbmc/stubs/httpHeaderStrncpy.c",
+        "function": null,
+        "line": 36
+      },
+      "httpHeaderStrncpy::pSrc$link1": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1258
+      },
+      "httpParserOnBodyCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 891
+      },
+      "httpParserOnBodyCallback::1::pNextWriteLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 898
+      },
+      "httpParserOnBodyCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 896
+      },
+      "httpParserOnBodyCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 897
+      },
+      "httpParserOnBodyCallback::1::shouldContinueParse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 895
+      },
+      "httpParserOnBodyCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 893
+      },
+      "httpParserOnBodyCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 891
+      },
+      "httpParserOnBodyCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 892
+      },
+      "httpParserOnHeaderFieldCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 700
+      },
+      "httpParserOnHeaderFieldCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 704
+      },
+      "httpParserOnHeaderFieldCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 705
+      },
+      "httpParserOnHeaderFieldCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 702
+      },
+      "httpParserOnHeaderFieldCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 700
+      },
+      "httpParserOnHeaderFieldCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 701
+      },
+      "httpParserOnHeaderValueCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 757
+      },
+      "httpParserOnHeaderValueCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 761
+      },
+      "httpParserOnHeaderValueCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 759
+      },
+      "httpParserOnHeaderValueCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 757
+      },
+      "httpParserOnHeaderValueCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 758
+      },
+      "httpParserOnHeadersCompleteCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 801
+      },
+      "httpParserOnHeadersCompleteCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 804
+      },
+      "httpParserOnHeadersCompleteCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 805
+      },
+      "httpParserOnHeadersCompleteCallback::1::shouldContinueParse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 803
+      },
+      "httpParserOnHeadersCompleteCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 801
+      },
+      "httpParserOnMessageBeginCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 640
+      },
+      "httpParserOnMessageBeginCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 642
+      },
+      "httpParserOnMessageBeginCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 640
+      },
+      "httpParserOnMessageCompleteCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 968
+      },
+      "httpParserOnMessageCompleteCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 970
+      },
+      "httpParserOnMessageCompleteCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 968
+      },
+      "httpParserOnStatusCallback": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 659
+      },
+      "httpParserOnStatusCallback::1::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 663
+      },
+      "httpParserOnStatusCallback::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 664
+      },
+      "httpParserOnStatusCallback::length": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 661
+      },
+      "httpParserOnStatusCallback::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 659
+      },
+      "httpParserOnStatusCallback::pLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 660
+      },
+      "http_major": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 33
+      },
+      "http_minor": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 34
+      },
+      "initializeParsingContextForFirstResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 987
+      },
+      "initializeParsingContextForFirstResponse::$tmp::return_value_strncmp": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1017
+      },
+      "initializeParsingContextForFirstResponse::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 987
+      },
+      "initializeParsingContextForFirstResponse::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 988
+      },
+      "isHeadResponse": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 292
+      },
+      "isValidHttpRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 54
+      },
+      "isValidHttpRequestHeaders::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 60
+      },
+      "isValidHttpRequestHeaders::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 56
+      },
+      "isValidHttpRequestHeaders::pRequestHeaders": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 54
+      },
+      "isValidHttpRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 89
+      },
+      "isValidHttpRequestInfo::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 95
+      },
+      "isValidHttpRequestInfo::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 97
+      },
+      "isValidHttpRequestInfo::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 91
+      },
+      "isValidHttpRequestInfo::pRequestInfo": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 89
+      },
+      "isValidHttpResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 160
+      },
+      "isValidHttpResponse::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 166
+      },
+      "isValidHttpResponse::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 168
+      },
+      "isValidHttpResponse::$tmp::tmp_if_expr$1": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 169
+      },
+      "isValidHttpResponse::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 162
+      },
+      "isValidHttpResponse::pResponse": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 160
+      },
+      "isValidHttpSendParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 244
+      },
+      "isValidHttpSendParsingContext::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 248
+      },
+      "isValidHttpSendParsingContext::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 249
+      },
+      "isValidHttpSendParsingContext::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 246
+      },
+      "isValidHttpSendParsingContext::pHttpParsingContext": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 244
+      },
+      "isValidTransportInterface": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 190
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 196
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr$0": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 196
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr$1": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 198
+      },
+      "isValidTransportInterface::$tmp::tmp_if_expr$2": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 198
+      },
+      "isValidTransportInterface::1::isValid": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 192
+      },
+      "isValidTransportInterface::pTransportInterface": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 190
+      },
+      "lastHeaderFieldLen": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 296
+      },
+      "lastHeaderValueLen": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 298
+      },
+      "lenient_flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 36
+      },
+      "llhttpParser": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 288
+      },
+      "llhttpSettings": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 289
+      },
+      "llhttp__internal_s": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 20
+      },
+      "llhttp__internal_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 20
+      },
+      "llhttp_cb": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 324
+      },
+      "llhttp_data_cb": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 323
+      },
+      "llhttp_errno": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 58
+      },
+      "llhttp_errno_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 85
+      },
+      "llhttp_execute": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 432
+      },
+      "llhttp_finish": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 114
+      },
+      "llhttp_finish_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 119
+      },
+      "llhttp_flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 87
+      },
+      "llhttp_flags_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 98
+      },
+      "llhttp_get_errno": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 484
+      },
+      "llhttp_init": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 374
+      },
+      "llhttp_lenient_flags": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 100
+      },
+      "llhttp_lenient_flags_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 105
+      },
+      "llhttp_method": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 121
+      },
+      "llhttp_method_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 169
+      },
+      "llhttp_settings_init": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 413
+      },
+      "llhttp_settings_s": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 321
+      },
+      "llhttp_settings_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 321
+      },
+      "llhttp_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 320
+      },
+      "llhttp_type": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 107
+      },
+      "llhttp_type_t": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 112
+      },
+      "mallocCanFail": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 32
+      },
+      "mallocCanFail::$tmp::return_value_malloc": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 35
+      },
+      "mallocCanFail::size": {
+        "file": "test/cbmc/sources/http_cbmc_state.c",
+        "function": null,
+        "line": 32
+      },
+      "method": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 32
+      },
+      "methodLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 356
+      },
+      "nondet_bool": {
+        "file": "test/cbmc/include/http_cbmc_state.h",
+        "function": null,
+        "line": 47
+      },
+      "onHeaderCallback": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 398
+      },
+      "on_body": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 348
+      },
+      "on_chunk_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 358
+      },
+      "on_chunk_header": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 357
+      },
+      "on_header_field": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 333
+      },
+      "on_header_field_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 363
+      },
+      "on_header_value": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 334
+      },
+      "on_header_value_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 364
+      },
+      "on_headers_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 345
+      },
+      "on_message_begin": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 328
+      },
+      "on_message_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 351
+      },
+      "on_status": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 332
+      },
+      "on_status_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 362
+      },
+      "on_url": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 331
+      },
+      "on_url_complete": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 361
+      },
+      "pBody": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 486
+      },
+      "pBuffer": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 335
+      },
+      "pBufferCur": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 294
+      },
+      "pContext": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 408
+      },
+      "pField": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 222
+      },
+      "pHeaderParsingCallback": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 449
+      },
+      "pHeaders": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 472
+      },
+      "pHost": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 369
+      },
+      "pLastHeaderField": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 295
+      },
+      "pLastHeaderValue": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 297
+      },
+      "pMethod": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 355
+      },
+      "pNetworkContext": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 255
+      },
+      "pPath": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 361
+      },
+      "pResponse": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 291
+      },
+      "pValueLen": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 225
+      },
+      "pValueLoc": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 224
+      },
+      "parseHttpResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1141
+      },
+      "parseHttpResponse::1::parsingStartLoc": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1146
+      },
+      "parseHttpResponse::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1145
+      },
+      "parseHttpResponse::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1141
+      },
+      "parseHttpResponse::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1142
+      },
+      "parseHttpResponse::parseLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1143
+      },
+      "pathLen": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 362
+      },
+      "processCompleteHeader": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 591
+      },
+      "processCompleteHeader::1::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 593
+      },
+      "processCompleteHeader::pParsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 591
+      },
+      "processLlhttpError": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1027
+      },
+      "processLlhttpError::$tmp::return_value_llhttp_get_errno": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1036
+      },
+      "processLlhttpError::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1029
+      },
+      "processLlhttpError::pHttpParser": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1027
+      },
+      "reason": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 26
+      },
+      "receiveAndParseHttpResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1978
+      },
+      "receiveAndParseHttpResponse::$tmp::return_value": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2041
+      },
+      "receiveAndParseHttpResponse::$tmp::tmp_if_expr": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2072
+      },
+      "receiveAndParseHttpResponse::1::currentReceived": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1984
+      },
+      "receiveAndParseHttpResponse::1::lastRecvTimeMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1987
+      },
+      "receiveAndParseHttpResponse::1::parsingContext": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1985
+      },
+      "receiveAndParseHttpResponse::1::retryTimeoutMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1988
+      },
+      "receiveAndParseHttpResponse::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1982
+      },
+      "receiveAndParseHttpResponse::1::shouldParse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1986
+      },
+      "receiveAndParseHttpResponse::1::shouldRecv": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1986
+      },
+      "receiveAndParseHttpResponse::1::timeSinceLastRecvMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1987
+      },
+      "receiveAndParseHttpResponse::1::timeoutReached": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1986
+      },
+      "receiveAndParseHttpResponse::1::totalReceived": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1983
+      },
+      "receiveAndParseHttpResponse::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1980
+      },
+      "receiveAndParseHttpResponse::pResponse": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1979
+      },
+      "receiveAndParseHttpResponse::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1978
+      },
+      "recv": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 253
+      },
+      "reqFlags": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 377
+      },
+      "respFlags": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 524
+      },
+      "send": {
+        "file": "source/interface/transport_interface.h",
+        "function": null,
+        "line": 254
+      },
+      "sendHttpBody": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1910
+      },
+      "sendHttpBody::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1915
+      },
+      "sendHttpBody::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1911
+      },
+      "sendHttpBody::pRequestBodyBuf": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1912
+      },
+      "sendHttpBody::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1910
+      },
+      "sendHttpBody::reqBodyBufLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1913
+      },
+      "sendHttpData": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1760
+      },
+      "sendHttpData::$tmp::return_value": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1823
+      },
+      "sendHttpData::1::bytesRemaining": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1768
+      },
+      "sendHttpData::1::bytesSent": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1767
+      },
+      "sendHttpData::1::lastSendTimeMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1769
+      },
+      "sendHttpData::1::pIndex": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1766
+      },
+      "sendHttpData::1::retryTimeoutMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1770
+      },
+      "sendHttpData::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1765
+      },
+      "sendHttpData::1::timeSinceLastSendMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1769
+      },
+      "sendHttpData::dataLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1763
+      },
+      "sendHttpData::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1761
+      },
+      "sendHttpData::pData": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1762
+      },
+      "sendHttpData::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1760
+      },
+      "sendHttpHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1872
+      },
+      "sendHttpHeaders::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1878
+      },
+      "sendHttpHeaders::1::shouldSendContentLength": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1879
+      },
+      "sendHttpHeaders::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1873
+      },
+      "sendHttpHeaders::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1874
+      },
+      "sendHttpHeaders::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1872
+      },
+      "sendHttpHeaders::reqBodyLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1875
+      },
+      "sendHttpHeaders::sendFlags": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1876
+      },
+      "sendHttpRequest": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2092
+      },
+      "sendHttpRequest::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2099
+      },
+      "sendHttpRequest::getTimestampMs": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2093
+      },
+      "sendHttpRequest::pRequestBodyBuf": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2095
+      },
+      "sendHttpRequest::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2094
+      },
+      "sendHttpRequest::pTransport": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2092
+      },
+      "sendHttpRequest::reqBodyBufLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2096
+      },
+      "sendHttpRequest::sendFlags": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 2097
+      },
+      "settings": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 41
+      },
+      "state": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 290
+      },
+      "statusCode": {
+        "file": "source/include/core_http_client.h",
+        "function": null,
+        "line": 502
+      },
+      "status_code": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 40
+      },
+      "strncpy": {
+        "file": "test/cbmc/stubs/strncpy.c",
+        "function": null,
+        "line": 49
+      },
+      "type": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 31
+      },
+      "upgrade": {
+        "file": "source/dependency/3rdparty/llhttp/include/llhttp.h",
+        "function": null,
+        "line": 37
+      },
+      "valueFound": {
+        "file": "source/include/core_http_client_private.h",
+        "function": null,
+        "line": 227
+      },
+      "writeRequestLine": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1467
+      },
+      "writeRequestLine::1::pBufferCur": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1474
+      },
+      "writeRequestLine::1::returnStatus": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1473
+      },
+      "writeRequestLine::1::toAddLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1475
+      },
+      "writeRequestLine::methodLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1469
+      },
+      "writeRequestLine::pMethod": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1468
+      },
+      "writeRequestLine::pPath": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1470
+      },
+      "writeRequestLine::pRequestHeaders": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1467
+      },
+      "writeRequestLine::pathLen": {
+        "file": "source/core_http_client.c",
+        "function": null,
+        "line": 1471
+      }
+    }
+  }
+}


### PR DESCRIPTION
This pull request extracts ctags support as a standalone module so it can be copied into other projects.  

Also modify ctags output to include the symbol kind (eg, "function").

Also advance version to 3.3


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
