### PR TITLE
Use universal_newlines to support older version of Python

### DIFF
--- a/src/cbmc_viewer/ctagst.py
+++ b/src/cbmc_viewer/ctagst.py
@@ -17,7 +17,7 @@ def popen(cmd, cwd=None, stdin=None, encoding=None):
 
     cmd = [str(word) for word in cmd]
     kwds = {'cwd': cwd,
-            'text': True,
+            'universal_newlines': True,
             'stdin': subprocess.PIPE,
             'stdout': subprocess.PIPE,
             'stderr': subprocess.PIPE}


### PR DESCRIPTION
Resolves #122 

*Description of changes:*

Replace the `text` parameter of `Popen` with `universal_newlines`, since `text` is only available in Python 3.7 and up (the default Python version on Ubuntu 18.04 is 3.6.8). The newer versions of Python still support `universal_newlines` for backward compatibility:

> New in version 3.7: text was added as a more readable alias for universal_newlines.

> The universal_newlines argument is equivalent to text and is provided for backwards compatibility.

Source: https://docs.python.org/3/library/subprocess.html#popen-constructor



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
