### PR TITLE
Lower 'no cbmc-viewer.json' logging from error to info

### DIFF
--- a/src/cbmc_viewer/configt.py
+++ b/src/cbmc_viewer/configt.py
@@ -21,7 +21,7 @@ class Config:
             return
 
         if not Path(config_file).exists():
-            logging.error("Config file does not exist: %s", config_file)
+            logging.info("Config file does not exist: %s", config_file)
             return
 
         config_data = parse.parse_json_file(config_file)


### PR DESCRIPTION
Viewer currently logs an error if the configuration file cbmc-viewer.json is missing.  Viewer does not depend on the configuration file, it is merely guided to better results by the configuration file.  This change lowers the error message to an info message (that is not displayed without the --verbose or --debug flags).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
