### PR TITLE
Remove macOS 10.15 in GitHub Actions "build-bottle" job

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -74,7 +74,7 @@ jobs:
     needs: homebrew-pr
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, macos-10.15]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Homebrew

--- a/tests/kani/Makefile
+++ b/tests/kani/Makefile
@@ -9,7 +9,7 @@ SHELL=/bin/bash
 
 KANI?=kani
 
-# ARCH is ubuntu or macos-10.15
+# ARCH is ubuntu
 ARCH?=ubuntu
 
 clone:
@@ -18,7 +18,6 @@ clone:
 
 # MacOS warning: If brew fails trying to install ctags over
 # universal-ctags, then replace ctags with universal-ctags
-# ./kani/scripts/setup/macos-10.15/install_deps.sh
 
 build:
 	PATH=$$HOME/.cargo/bin:$$PATH $(MAKE) build_


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

GitHub is planning to deprecate macOS 10.15 GitHub actions next month and is failing certain CI builds to raise awareness ([link](https://github.com/actions/virtual-environments/issues/5583))

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
