### PR TITLE
Set minimum python version to 3.7

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,7 +24,7 @@ install_requires =
     jinja2
     setuptools
     voluptuous
-python_requires = >=3.6
+python_requires = >=3.7
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
Required to satisfy the reqs of voluptuous 0.14.0 which now uses type annotations, a python 3.7+ feature.

Fixes #146 

Sets the minimum python version to 3.7.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
