### PR TITLE
CI jobs: remove use of deprecated set-output

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -128,15 +128,14 @@ jobs:
       - name: Get Package Path
         id: get_package_path
         run: |
-          bottle_name="$(ls *.tar.gz)"
-          echo "::set-output name=bottle::$bottle_name"
+          echo "bottle_name=$(ls *.tar.gz)" >> $GITHUB_OUTPUT
 
       - name: Get File Name
         id: get_file_name
         run: |
           brew install jq
           file_name="$(cat *.json | jq -r '."${{ env.TAP }}/${{ env.FORMULA }}".bottle.tags[].filename')"
-          echo "::set-output name=file_name::$file_name"
+          echo "file_name=$file_name" >> $GITHUB_OUTPUT
 
       - name: Upload bottles as artifact
         uses: actions/upload-artifact@main

--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -32,8 +32,7 @@ jobs:
       - name: set asset path and name
         id: get_package_name
         run: |
-          package_name="$(ls dist/*.whl | cut -d "/" -f 2)"
-          echo "::set-output name=package_name::$package_name"
+          echo "package_name=$(ls dist/*.whl | cut -d / -f 2)" >> $GITHUB_OUTPUT
       - name: Upload release binary
         uses: actions/upload-release-asset@v1.0.2
         with:


### PR DESCRIPTION
This is deprecated since October 2022.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
