### PR TITLE
Avoid name clash when uploading artifacts from multiple platforms

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -139,15 +139,13 @@ jobs:
           echo "::set-output name=file_name::$file_name"
 
       - name: Upload bottles as artifact
-        uses: actions/upload-artifact@main
+        uses: actions/upload-artifact@v4
         with:
-          name: bottles
+          name: bottle-${{ matrix.os }}
           path: '*.bottle.*'
 
       - name: Upload release binary
         uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ${{ steps.get_package_path.outputs.bottle }}
@@ -162,7 +160,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v3
       with:
-        name: bottles
+        pattern: bottle-*
 
     - name: Authenticate GitHub workflow to AWS
       uses: aws-actions/configure-aws-credentials@v4
@@ -192,6 +190,6 @@ jobs:
 
     - name: Generate and merge bottle DSL
       run: |
-        brew bottle --merge --write $(ls *.json)
+        brew bottle --merge --write $(ls bottle-*/*.json)
         cd $(brew --repo ${{ env.TAP }})
         git push fork-repo bump-${{ env.FORMULA }}-${{ env.VERSION }}


### PR DESCRIPTION
More recent versions of upload-artifact refuse to upload/merge artifacts with the same name.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
