### PR TITLE
Do not unnecessarily re-install jq

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -134,7 +134,6 @@ jobs:
       - name: Get File Name
         id: get_file_name
         run: |
-          brew install jq
           file_name="$(cat *.json | jq -r '."${{ env.TAP }}/${{ env.FORMULA }}".bottle.tags[].filename')"
           echo "::set-output name=file_name::$file_name"
 


### PR DESCRIPTION
Earlier steps already depend on jq.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
