### PR TITLE
fixup! CI jobs: remove use of deprecated set-output

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -146,7 +146,7 @@ jobs:
         uses: actions/upload-release-asset@v1.0.2
         with:
           upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ steps.get_package_path.outputs.bottle }}
+          asset_path: ${{ steps.get_package_path.outputs.bottle_name }}
           asset_name: ${{ steps.get_file_name.outputs.file_name }}
           asset_content_type: application/x-gzip
 


### PR DESCRIPTION
Fixes the output name to match the variable name that was changed in fbf6eca0. (The change in fbf6eca0 was unintentional, but makes it more uniform with other output names.)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
