### PR TITLE
Extend permissions to make update-pr work

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -155,6 +155,7 @@ jobs:
     runs-on: macos-latest
     permissions:
       id-token: write
+      contents: write
     steps:
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
This is an attempt to also have update-pr use a personal-access token - the build-bottle jobs use the very same steps to access secretsmanager and seem to be able to use the resulting token.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
