### PR TITLE
Fix update-pr workflow

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -72,13 +72,13 @@ jobs:
       - name: Configure git user name and email
         run: |
           git config --global user.name ${{ env.BOT_USER }}
-          git config --global user.email $BOT_EMAIL
+          git config --global user.email ${{ env.BOT_EMAIL }}
 
       - name: Create homebrew PR
         run: |
           brew tap ${{ env.TAP }}
           brew update-reset
-          brew bump-formula-pr --tag "${{ env.RELEASE_TAG }}" --revision "$GITHUB_SHA" ${{ env.TAP }}/${{ env.FORMULA }} --force
+          brew bump-formula-pr --tag "${{ env.RELEASE_TAG }}" --revision "${{ github.sha }}" ${{ env.TAP }}/${{ env.FORMULA }} --force
 
   build-bottle:
     needs: homebrew-pr
@@ -102,7 +102,7 @@ jobs:
 
       - name: Fetch secrets
         run: |
-          echo "FORK_REPO=https://$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')@github.com/$BOT_USER/homebrew-$(echo $TAP |cut -d / -f 2).git" >> $GITHUB_ENV
+          echo "FORK_REPO=https://$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')@github.com/${{ env.BOT_USER }}/homebrew-$(echo ${{ env.TAP }} |cut -d / -f 2).git" >> $GITHUB_ENV
           echo "GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')" >> $GITHUB_ENV
 
       - name: Checkout PR
@@ -110,7 +110,7 @@ jobs:
           brew tap ${{ env.TAP }}
           brew update-reset
           cd $(brew --repo ${{ env.TAP }})
-          git remote add fork-repo $FORK_REPO
+          git remote add fork-repo ${{ env.FORK_REPO }}
           git fetch fork-repo
           git checkout -B bump-${{ env.FORMULA }}-${{ env.VERSION }} fork-repo/bump-${{ env.FORMULA }}-${{ env.VERSION }}
 
@@ -121,7 +121,7 @@ jobs:
 
       - name: Build bottle
         run: |
-          brew test-bot --tap ${{ env.TAP }} --testing-formulae ${{ env.TAP }}/${{ env.FORMULA }} --only-formulae --root-url=https://github.com/$GITHUB_REPOSITORY/releases/download/${{ env.RELEASE_TAG }}
+          brew test-bot --tap ${{ env.TAP }} --testing-formulae ${{ env.TAP }}/${{ env.FORMULA }} --only-formulae --root-url=https://github.com/${{ github.repository }}/releases/download/${{ env.RELEASE_TAG }}
 
       - name: Get Package Path
         id: get_package_path
@@ -168,19 +168,19 @@ jobs:
     - name: Fetch secrets
       run: |
         echo "BOT_EMAIL=$(aws secretsmanager get-secret-value --secret-id BOT_EMAIL | jq -r '.SecretString')" >> $GITHUB_ENV
-        echo "FORK_REPO=https://$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')@github.com/$BOT_USER/homebrew-$(echo $TAP |cut -d / -f 2).git" >> $GITHUB_ENV
+        echo "FORK_REPO=https://$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')@github.com/${{ env.BOT_USER }}/homebrew-$(echo ${{ env.TAP }} |cut -d / -f 2).git" >> $GITHUB_ENV
 
     - name: Configure git user name and email
       run: |
         git config --global user.name ${{ env.BOT_USER }}
-        git config --global user.email $BOT_EMAIL
+        git config --global user.email ${{ env.BOT_EMAIL }}
 
     - name: Checkout PR
       run: |
         brew tap ${{ env.TAP }}
         brew update-reset
         cd $(brew --repo ${{ env.TAP }})
-        git remote add fork-repo $FORK_REPO
+        git remote add fork-repo ${{ env.FORK_REPO }}
         git fetch fork-repo
         git checkout -B bump-${{ env.FORMULA }}-${{ env.VERSION }} fork-repo/bump-${{ env.FORMULA }}-${{ env.VERSION }}
 

--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -102,10 +102,8 @@ jobs:
 
       - name: Fetch secrets
         run: |
-          echo "BOT_EMAIL=$(aws secretsmanager get-secret-value --secret-id BOT_EMAIL | jq -r '.SecretString')" >> $GITHUB_ENV
-          echo "HOMEBREW_GITHUB_API_TOKEN=$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')" >> $GITHUB_ENV
-          echo "FORK_REPO=https://$HOMEBREW_GITHUB_API_TOKEN@github.com/$BOT_USER/homebrew-$(echo $TAP |cut -d / -f 2).git" >> $GITHUB_ENV
-          echo "GITHUB_TOKEN=$HOMEBREW_GITHUB_API_TOKEN" >> $GITHUB_ENV
+          echo "FORK_REPO=https://$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')@github.com/$BOT_USER/homebrew-$(echo $TAP |cut -d / -f 2).git" >> $GITHUB_ENV
+          echo "GITHUB_TOKEN=$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')" >> $GITHUB_ENV
 
       - name: Checkout PR
         run: |
@@ -161,10 +159,6 @@ jobs:
       with:
         pattern: bottle-*
 
-    - name: Set up Homebrew
-      id: set-up-homebrew
-      uses: Homebrew/actions/setup-homebrew@master
-
     - name: Authenticate GitHub workflow to AWS
       uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -174,14 +168,12 @@ jobs:
     - name: Fetch secrets
       run: |
         echo "BOT_EMAIL=$(aws secretsmanager get-secret-value --secret-id BOT_EMAIL | jq -r '.SecretString')" >> $GITHUB_ENV
-        echo "HOMEBREW_GITHUB_API_TOKEN=$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')" >> $GITHUB_ENV
-        echo "FORK_REPO=https://$HOMEBREW_GITHUB_API_TOKEN@github.com/$BOT_USER/homebrew-$(echo $TAP |cut -d / -f 2).git" >> $GITHUB_ENV
-        echo "GITHUB_TOKEN=$HOMEBREW_GITHUB_API_TOKEN" >> $GITHUB_ENV
+        echo "FORK_REPO=https://$(aws secretsmanager get-secret-value --secret-id RELEASE_CI_ACCESS_TOKEN | jq -r '.SecretString')@github.com/$BOT_USER/homebrew-$(echo $TAP |cut -d / -f 2).git" >> $GITHUB_ENV
 
     - name: Configure git user name and email
       run: |
         git config --global user.name ${{ env.BOT_USER }}
-        git config --global user.email BOT_EMAIL
+        git config --global user.email $BOT_EMAIL
 
     - name: Checkout PR
       run: |


### PR DESCRIPTION
We cannot rely on values in GITHUB_ENV that were stored earlier in the same step. Instead, directly query secretsmanager as needed.

Also fixes the committer-email that used the literal `BOT_EMAIL` string rather than the variable.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
