### PR TITLE
Use cElementTree to reduce memory consumption

### DIFF
--- a/src/cbmc_viewer/parse.py
+++ b/src/cbmc_viewer/parse.py
@@ -4,7 +4,7 @@
 """Parsing of xml and json files with limited error handling."""
 
 from pathlib import Path
-from xml.etree import ElementTree
+import xml.etree.cElementTree as ElementTree
 
 import json
 import logging


### PR DESCRIPTION
*Description of changes:*

Parsing CBMC's results in a memory consumption that is 100 times the size of the input file. Switching to cElementTree appears to halve the memory footprint, which can make the difference as to whether this fits into host memory. We could reduce the memory footprint a lot by iterating (and cleaning up) over the input XML nodes, but this requires a much larger re-architecting of the source.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
