### PR TITLE
Use action-gh-release to replace deprecated upload-release-asset

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -136,12 +136,6 @@ jobs:
         run: |
           echo "bottle_name=$(ls *.tar.gz)" >> $GITHUB_OUTPUT
 
-      - name: Get File Name
-        id: get_file_name
-        run: |
-          file_name="$(cat *.json | jq -r '."${{ env.TAP }}/${{ env.FORMULA }}".bottle.tags[].filename')"
-          echo "file_name=$file_name" >> $GITHUB_OUTPUT
-
       - name: Upload bottles as artifact
         uses: actions/upload-artifact@v4
         with:
@@ -149,12 +143,9 @@ jobs:
           path: '*.bottle.*'
 
       - name: Upload release binary
-        uses: actions/upload-release-asset@v1.0.2
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ steps.get_package_path.outputs.bottle_name }}
-          asset_name: ${{ steps.get_file_name.outputs.file_name }}
-          asset_content_type: application/x-gzip
+          files: ${{ steps.get_package_path.outputs.bottle_name }}
 
   update-pr:
     needs: build-bottle

--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -38,12 +38,9 @@ jobs:
         run: |
           echo "package_name=$(ls dist/*.whl | cut -d / -f 2)" >> $GITHUB_OUTPUT
       - name: Upload release binary
-        uses: actions/upload-release-asset@v1.0.2
+        uses: softprops/action-gh-release@v2
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: dist/${{ steps.get_package_name.outputs.package_name }}
-          asset_name: ${{ steps.get_package_name.outputs.package_name }}
-          asset_content_type: application/zip
+          files: dist/${{ steps.get_package_name.outputs.package_name }}
       - name: Upload to PyPi
         env:
           TWINE_USERNAME: __token__


### PR DESCRIPTION
upload-release-asset is long deprecated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
