### PR TITLE
Support XML files containing failed results but no goto_trace field.

### DIFF
--- a/src/cbmc_viewer/tracet.py
+++ b/src/cbmc_viewer/tracet.py
@@ -331,7 +331,9 @@ def parse_xml_traces(xmlfile, root=None):
             name, status = line.get('property'), line.get('status')
             if status == 'SUCCESS' or status == 'UNKNOWN':
                 continue
-            traces[name] = parse_xml_trace(line.find('goto_trace'), root)
+            trace = line.find('goto_trace')
+            if trace is not None:
+                traces[name] = parse_xml_trace(trace, root)
         return traces
 
     # cbmc produced only a one trace after being run with --stop-on-fail


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Some CBMC solvers like CVC5 can generate a cbmc.xml file containing failed verification results but without the failure trace (or a goto_trace field). With the current behavior, cbmc_viewer will crash when invoked because line 353 will try to iterate through None. This commit fixes this bug.

Here is a sample XML file that triggers this crash

<?xml version="1.0" encoding="UTF-8"?>
<cprover>
<program>CBMC 6.3.1 (cbmc-6.3.1)</program>
<message type="STATUS-MESSAGE">
  <text>CBMC version 6.3.1 (cbmc-6.3.1) 64-bit x86_64 linux</text>
</message>

...

<message type="STATUS-MESSAGE">
  <text>Running SMT2 ALL (with FPA) using CVC5</text>
</message>

<message type="STATUS-MESSAGE">
  <text>Runtime Solver: 0.00640582s</text>
</message>

<message type="STATUS-MESSAGE">
  <text>Runtime decision procedure: 0.00703132s</text>
</message>

<result property="malloc.assertion.1" status="SUCCESS">
  <location file="&lt;builtin-library-malloc&gt;" function="malloc" line="31" working-directory="xxx"/>
</result>

<result property="malloc.assertion.2" status="SUCCESS">
  <location file="&lt;builtin-library-malloc&gt;" function="malloc" line="36" working-directory="xxx"/>
</result>

<result property="harness.overflow.1" status="ERROR">
  <location file="main_harness.c" function="harness" line="48" working-directory="xxx"/>
</result>

<message type="STATUS-MESSAGE">
  <text>VERIFICATION ERROR</text>
</message>

<cprover-status>ERROR</cprover-status>

</cprover>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
