### PR TITLE
Change 2 logging "warnings" messages to be "info" messages instead.

### DIFF
--- a/src/cbmc_viewer/markup_code.py
+++ b/src/cbmc_viewer/markup_code.py
@@ -63,13 +63,13 @@ class Code:
             # CBMC implementation.
             #   * We skip source annotation: We treat the file as a
             #     zero-length file with nothing to annotate.
-            #   * We print a simple warning message: The relative path
+            #   * We print a simple info message: The relative path
             #     to the file in the symbol table was interpreted by
             #     the symbol table parser as relative to the working
-            #     directory.  Printing this path in the warning is
+            #     directory.  Printing this path in the message is
             #     confusing, so we print just the base name.
-            logging.warning("Skipping source file annotation: %s",
-                            os.path.basename(path))
+            logging.info("Skipping source file annotation: %s",
+                         os.path.basename(path))
             self.lines = []
 
         self.filename = path

--- a/src/cbmc_viewer/symbol_table.py
+++ b/src/cbmc_viewer/symbol_table.py
@@ -191,11 +191,11 @@ def symbol_definitions(goto, wkdir, srcdir=None):
 
         srcloc = srcloct.make_srcloc(src, None, num, wkdir, srcdir)
         if sym in symbols and srcloc != symbols[sym]:
-            logging.warning("Skipping redefinition of symbol name: %s", sym)
-            logging.warning("  Old symbol %s: file %s, line %s",
-                            sym, symbols[sym]["file"], symbols[sym]["line"])
-            logging.warning("  New symbol %s: file %s, line %s",
-                            sym, srcloc["file"], srcloc["line"])
+            logging.info("Skipping redefinition of symbol name: %s", sym)
+            logging.info("  Old symbol %s: file %s, line %s",
+                         sym, symbols[sym]["file"], symbols[sym]["line"])
+            logging.info("  New symbol %s: file %s, line %s",
+                         sym, srcloc["file"], srcloc["line"])
             continue
         symbols[sym] = srcloc
 


### PR DESCRIPTION
This hugely reduces noisy output on stdout when processing a large number of proofs in CI, as in mlkem-native and mldsa-native repos.

Fixes #184 
Fixes #133

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
