### PR TITLE
Do not use Ubuntu 20.04 in CI

### DIFF
--- a/.github/workflows/release-pypi.yaml
+++ b/.github/workflows/release-pypi.yaml
@@ -10,7 +10,7 @@ env:
 jobs:
   upload-to-pypi:
     name: Upload to PyPi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,7 @@ env:
 jobs:
   Release:
     name: CBMC viewer release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write

--- a/.github/workflows/run-differential-tests.yaml
+++ b/.github/workflows/run-differential-tests.yaml
@@ -28,7 +28,7 @@ jobs:
           cbmc_latest_release=$(get_latest_release diffblue/cbmc)
           litani_latest_release=$(get_latest_release awslabs/aws-build-accumulator)
           curl -o cbmc.deb -L \
-            https://github.com/diffblue/cbmc/releases/download/$cbmc_latest_release/ubuntu-20.04-$cbmc_latest_release-Linux.deb
+            https://github.com/diffblue/cbmc/releases/download/$cbmc_latest_release/ubuntu-24.04-$cbmc_latest_release-Linux.deb
           curl -o litani.deb -L \
             https://github.com/awslabs/aws-build-accumulator/releases/download/$litani_latest_release/litani-$litani_latest_release.deb
           sudo apt-get update \


### PR DESCRIPTION
This has been deprecated by GitHub for its (free) security support has expired.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
