### PR TITLE
Brew untap hashicorp

### DIFF
--- a/.github/workflows/release-brew.yaml
+++ b/.github/workflows/release-brew.yaml
@@ -116,6 +116,7 @@ jobs:
       - name: Checkout PR
         run: |
           brew tap ${{ env.TAP }}
+          brew untap --force hashicorp/tap
           brew update-reset
           cd $(brew --repo ${{ env.TAP }})
           git remote add fork-repo ${{ env.FORK_REPO }}


### PR DESCRIPTION
*Description of changes:*

`brew test-bot` eventually walks all formulae to determine what might depend on cbmc-viewer, thereby walking into what appears to be a broken formula at `hashicorp/tap/vagrant`. This tap is entirely unrelated and also unnecessary for our purposes, so just remove it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
